### PR TITLE
PULSE-6863 - Flow Create Message broken when using subdir

### DIFF
--- a/static/coffee/flows/services.coffee
+++ b/static/coffee/flows/services.coffee
@@ -102,6 +102,8 @@ app.service "utils", ['$modal', ($modal) ->
       arr[i] for arr in arguments
 
   openModal: (templateUrl, controller, resolveObj) ->
+    if typeof window.subdir is "string" and window.subdir.length > 0
+      templateUrl = '/' + window.subdir + templateUrl
     $modal.open
       keyboard: false
       templateUrl: templateUrl
@@ -1004,7 +1006,7 @@ app.factory 'Flow', ['$rootScope', '$window', '$http', '$timeout', '$interval', 
           return cfg
 
     fetchRecentMessages: (exit_uuids, to_uuid) ->
-      return $http.get('/flow/recent_messages/' + Flow.flowUUID + '/?exits=' + exit_uuids.join() + '&to=' + to_uuid).success (data) ->
+      return $http.get((if typeof window.subdir == "string" && window.subdir.length > 0 then '/' +  window.subdir else '') + '/flow/recent_messages/' + Flow.flowUUID + '/?exits=' + exit_uuids.join() + '&to=' + to_uuid).success (data) ->
 
     fetch: (flowUUID, onComplete = null) ->
 

--- a/static/coffee/flows/widgets.coffee
+++ b/static/coffee/flows/widgets.coffee
@@ -84,7 +84,7 @@ app.directive "ussd", [ "$rootScope", "$log", "Flow", ($rootScope, $log, Flow) -
       $rootScope.characters = if scope.USSD_MENU then MESSAGE_LENGTH - textMenuLength else MESSAGE_LENGTH - textLength
 
   return {
-    templateUrl: "/partials/ussd_directive"
+    templateUrl: (if typeof window.subdir == "string" && window.subdir.length > 0 then '/' +  window.subdir else '') + "/partials/ussd_directive"
     restrict: "A"
     link: link
     scope: true
@@ -137,7 +137,7 @@ app.directive "msg", [ "$log", "Flow", ($log, Flow) ->
         scope.message = ""
 
   return {
-    templateUrl: "/partials/msg_directive"
+    templateUrl: (if typeof window.subdir == "string" && window.subdir.length > 0 then '/' +  window.subdir else '') +  "/partials/msg_directive"
     restrict: "A"
     link: link
     scope: {
@@ -532,7 +532,7 @@ app.directive "omnibox", [ "$timeout", "$log", "Flow", ($timeout, $log, Flow) ->
       multiple: multiple
       createSearchChoice: options.createSearchChoice
       ajax:
-        url: "/contact/omnibox/?types=" + types
+        url: (if typeof window.subdir == "string" && window.subdir.length > 0 then '/' +  window.subdir else '') + "/contact/omnibox/?types=" + types
         dataType: "json"
         data: (term, page, context) ->
           q = term


### PR DESCRIPTION
Flow Create Message broken when using subdir.

Prior to applying this patch:

1. Enable the subdir in the docker-compose.yml file SUB_DIR var.
2. Navigate the flow editor ex: /subdir/flow/editor/a69cf345-6729-4de8-83fc-7b90a1607c5c/
3. Click `Create Message` and you will notice that no modal dialog pops up.
4. Open the javascript console and you will see an error similar to:  `GET https://p35.dev.istresearch.com/partials/node_editor 404 (Not Found)`

After applying this fix, hard refresh the page and you should notice the modal dialog appears as expected.
