### PR TITLE
P4 457 - New view to assign user to organization

### DIFF
--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -545,6 +545,7 @@ class OrgCRUDL(SmartCRUDL):
         "edit",
         "edit_sub_org",
         "join",
+        "assign_user",
         "grant",
         "accounts",
         "create_login",
@@ -1813,6 +1814,62 @@ class OrgCRUDL(SmartCRUDL):
 
             context["org"] = self.get_object()
             return context
+
+    class AssignUser(SmartFormView):
+        class ServiceForm(forms.Form):
+            organization = forms.ModelChoiceField(queryset=Org.objects.all(), empty_label=None)
+            user_group = forms.ChoiceField(
+                choices=(("A", _("Administrators")), ("E", _("Editors")), ("V", _("Viewers")), ("S", _("Surveyors"))),
+                required=True,
+                initial="E",
+                label=_("User group"),
+            )
+            username = forms.CharField(required=True, label=_("Username"))
+
+        form_class = ServiceForm
+        title = _("Assign User to Organization")
+        fields = ("organization", "user_group", "username")
+
+        # valid form means we set our org and redirect to their inbox
+        def form_valid(self, form):
+
+            org = form.cleaned_data["organization"]
+            user_group = form.cleaned_data["user_group"]
+            username = form.cleaned_data["username"]
+
+            user = User.objects.filter(username__iexact=username).first()
+
+            if org:
+                if user_group == "A":
+                    org.administrators.add(user)
+                    org.editors.remove(user)
+                    org.surveyors.remove(user)
+                    org.viewers.remove(user)
+                elif user_group == "E":
+                    org.editors.add(user)
+                    org.administrators.remove(user)
+                    org.surveyors.remove(user)
+                    org.viewers.remove(user)
+                elif user_group == "S":
+                    org.surveyors.add(user)
+                    org.administrators.remove(user)
+                    org.editors.remove(user)
+                    org.viewers.remove(user)
+                else:
+                    org.viewers.add(user)
+                    org.administrators.remove(user)
+                    org.editors.remove(user)
+                    org.surveyors.remove(user)
+
+                # when a user's role changes, delete any API tokens they're no longer allowed to have
+                api_roles = APIToken.get_allowed_roles(org, user)
+                for token in APIToken.objects.filter(org=org, user=user).exclude(role__in=api_roles):
+                    token.release()
+
+                org.save()
+
+            success_url = reverse("orgs.org_assign_user")
+            return HttpResponseRedirect(success_url)
 
     class Surveyor(SmartFormView):
         class PasswordForm(forms.Form):

--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -361,6 +361,7 @@ PERMISSIONS = {
         "edit",
         "edit_sub_org",
         "export",
+        "assign_user",
         "grant",
         "home",
         "import",

--- a/templates/includes/nav.haml
+++ b/templates/includes/nav.haml
@@ -49,7 +49,7 @@
   -if request.user.is_superuser or perms.orgs.org_manage
     -if not user_org
       %li.nav-orgs
-        %a.icon-nav-orgs{href:"{% url 'orgs.org_manage' %}?search=Nyaruka", class:"{% active request 'org' %}"}
+        %a.icon-nav-orgs{href:"{% url 'orgs.org_manage' %}?search=", class:"{% active request 'org' %}"}
           .title
             -trans "orgs"
 


### PR DESCRIPTION
This PR adds a new form view accessible to the superuser for assigning users to an existing ORG without the email invitation workflow.

**Testing:**
1) Start RapidPro.
2) Go to `<base>/org/assign_user` when logging in as the RapidPro Superuser.
3) Select an organization, type in the username of an existing user, select the role for the user.
4) Submit the form.
5) Log in as the user and confirm access to the organization.