### PR TITLE
PULSE-7012 - Default Android channel name to phone number and alert email to 'none'

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -1013,11 +1013,14 @@ class Channel(TembaModel):
         if not self.country:  # pragma: needs cover
             self.country = ContactURN.derive_country_from_tel(phone)
 
-        self.alert_email = user.email
+        # NOTE: leaving alert_email field empty
+        #self.alert_email = user.email
         self.org = org
         self.is_active = True
         self.claim_code = None
         self.address = phone
+        # default channel name to phone number
+        self.name = phone
         self.save()
 
         org.normalize_contact_tels()


### PR DESCRIPTION
- NOTE: I commented out the old email logic since I'm not sure what's preferred.. figured better to leave it than remove it in case we're merging in rapidpro's changes and wanted to know why it was removed.. but, either way works for me