### PR TITLE
Pulse 7090

### DIFF
--- a/templates/channels/channel_read_list.haml
+++ b/templates/channels/channel_read_list.haml
@@ -46,9 +46,9 @@
           {% if channel.channel_type == 'T' %}
             Twilio Address{% endif %}
           {% if channel.channel_type == 'BWD' %}
-            Bandwidth Domestic Address{% endif %}
+            Bandwidth Domestic - {% endif %}
           {% if channel.channel_type == 'BWI' %}
-            Bandwidth International ({{channel.uuid}}) {% endif %}
+            Bandwidth International - {% endif %}
 
           {{ channel.get_address_display }}
           -with channel.get_sender as sender and channel.get_caller as caller


### PR DESCRIPTION
Simple haml modification that will (hopefully) suffice.

The channel display should present as "[Bandwidth logo] BWI - [Sender ID]".