### PR TITLE
PULSE-7093 - Preferred channel in flow - The channel should display as "BWI: [senderID]"

### DIFF
--- a/temba/channels/types/bandwidth/views.py
+++ b/temba/channels/types/bandwidth/views.py
@@ -160,7 +160,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         }
 
         channel = Channel.create(
-            org, user, country, "BWD", name=account_sid, address=phone_number, role=role, config=config,
+            org, user, country, "BWD", name=phone_number, address=phone_number, role=role, config=config,
             uuid=self.uuid
         )
 

--- a/temba/channels/types/bandwidth_international/views.py
+++ b/temba/channels/types/bandwidth_international/views.py
@@ -125,7 +125,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             Channel.CONFIG_CALLBACK_DOMAIN: callback_domain
         }
 
-        channel = Channel.create(address=bwi_sender, org=org, user=user, channel_type="BWI", name=account_sid,
+        channel = Channel.create(address=bwi_sender, org=org, user=user, channel_type="BWI", name=bwi_sender,
                                  role=role, config=config, uuid=self.uuid, country="")
 
         channel.config[Channel.CONFIG_KEY] = channel.pk


### PR DESCRIPTION
Existing channels will need to have the name set to the address in the postgresql database prior to this fix working.

Essentially we're now duplicating the address into the channel.name field to avoid modifying any RP core files.

Moving forward if the account_sid is needed it should be retrieved from the channel.config['account_sid'] json field in posgres.