### PR TITLE
P4-1021 - Fix Android channel display in home/list view

### DIFF
--- a/templates/channels/channel_read_list.haml
+++ b/templates/channels/channel_read_list.haml
@@ -40,9 +40,16 @@
       .formax-icon{class:'{{ channel|channel_icon }}'}
       .formax-container
         %div.formax-summary
-          {% if channel.channel_type == 'A' %}{{ channel.device }}
-          -if channel.os
-            (v{{channel.os}}){% endif %}
+          -if channel.channel_type == 'A'
+            -# Android channel format
+            -if not channel.name or channel.name == channel.address
+              -# no name defined - or name equals phone number (default); show device model + version
+              {{channel.device}}
+              -if channel.os
+                (v{{channel.os}})
+            -else
+              {{channel.name}}
+
           {% if channel.channel_type == 'T' %}
             Twilio Address{% endif %}
           {% if channel.channel_type == 'BWD' %}


### PR DESCRIPTION
- logic comes from @martinezah and is basically this:
  - name, if set, otherwise the model, be displayed first, then the phone number after
  - And if the name == phone number, treat it like the name's not set