### PR TITLE
hasattr() always true for SUB_DIR.

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1920,7 +1920,7 @@ class ChannelCRUDL(SmartCRUDL):
             context["configuration_urls"] = channel_type.get_configuration_urls(self.object)
             context["show_public_addresses"] = channel_type.show_public_addresses
 
-            if settings.SUB_DIR:
+            if hasattr(settings, 'SUB_DIR') && settings.SUB_DIR:
                 context['subdir'] = settings.SUB_DIR.replace("/", "").replace("\\", "")
             return context
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1920,7 +1920,7 @@ class ChannelCRUDL(SmartCRUDL):
             context["configuration_urls"] = channel_type.get_configuration_urls(self.object)
             context["show_public_addresses"] = channel_type.show_public_addresses
 
-            if hasattr(settings, 'SUB_DIR'):
+            if settings.SUB_DIR:
                 context['subdir'] = settings.SUB_DIR.replace("/", "").replace("\\", "")
             return context
 

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1920,7 +1920,7 @@ class ChannelCRUDL(SmartCRUDL):
             context["configuration_urls"] = channel_type.get_configuration_urls(self.object)
             context["show_public_addresses"] = channel_type.show_public_addresses
 
-            if hasattr(settings, 'SUB_DIR') && settings.SUB_DIR:
+            if hasattr(settings, 'SUB_DIR') and settings.SUB_DIR:
                 context['subdir'] = settings.SUB_DIR.replace("/", "").replace("\\", "")
             return context
 

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -223,11 +223,11 @@ class SubdirMiddleware:
 
     def __init__(self, get_response=None):
         self.get_response = get_response
-        if hasattr(settings, 'SUB_DIR') && settings.SUB_DIR:
+        if hasattr(settings, 'SUB_DIR') and settings.SUB_DIR:
             self.subdir = settings.SUB_DIR.replace("/", "").replace("\\", "")
 
     def __call__(self, request):
-        if hasattr(settings, 'SUB_DIR') && settings.SUB_DIR:
+        if hasattr(settings, 'SUB_DIR') and settings.SUB_DIR:
             request.subdir = self.subdir
         response = self.get_response(request)
         return response

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -223,11 +223,11 @@ class SubdirMiddleware:
 
     def __init__(self, get_response=None):
         self.get_response = get_response
-        if settings.SUB_DIR:
+        if hasattr(settings, 'SUB_DIR') && settings.SUB_DIR:
             self.subdir = settings.SUB_DIR.replace("/", "").replace("\\", "")
 
     def __call__(self, request):
-        if settings.SUB_DIR:
+        if hasattr(settings, 'SUB_DIR') && settings.SUB_DIR:
             request.subdir = self.subdir
         response = self.get_response(request)
         return response

--- a/temba/middleware.py
+++ b/temba/middleware.py
@@ -223,11 +223,11 @@ class SubdirMiddleware:
 
     def __init__(self, get_response=None):
         self.get_response = get_response
-        if hasattr(settings, 'SUB_DIR'):
+        if settings.SUB_DIR:
             self.subdir = settings.SUB_DIR.replace("/", "").replace("\\", "")
 
     def __call__(self, request):
-        if hasattr(settings, 'SUB_DIR'):
+        if settings.SUB_DIR:
             request.subdir = self.subdir
         response = self.get_response(request)
         return response


### PR DESCRIPTION
 Since `hasattr(settings, 'SUB_DIR'):` is always true even when settings.SUB_DIR is None, replace it with `if settings.SUB_DIR:` so that we protect the IF branch from crashing when SUB_DIR is None (not defined as an ENV var).