### PR TITLE
P4-1086 BWI tweaks

### DIFF
--- a/temba/channels/types/bandwidth_international/tests.py
+++ b/temba/channels/types/bandwidth_international/tests.py
@@ -29,7 +29,7 @@ class BandwidthTypeTest(TembaTest):
         response = self.client.get(claim_bandwidth, follow=True)
         self.assertEqual(response.request["PATH_INFO"], reverse("orgs.org_bandwidth_international_connect"))
 
-        # attach a Bandwidth accont to the org
+        # attach a Bandwidth account to the org
         self.org.config = {BWI_USERNAME: "bwi-username", BWI_PASSWORD: "bwi-password"}
         self.org.save()
 

--- a/temba/channels/types/bandwidth_international/tests.py
+++ b/temba/channels/types/bandwidth_international/tests.py
@@ -5,7 +5,7 @@ from bandwidth.messaging.api_exception_module import BandwidthMessageAPIExceptio
 from django.urls import reverse
 
 from temba.channels.models import Channel
-from temba.orgs.models import BWI_ACCOUNT_SID, BWI_ACCOUNT_TOKEN
+from temba.orgs.models import BWI_USERNAME, BWI_PASSWORD
 from temba.tests import TembaTest
 from temba.tests.bandwidth import MockRequestValidator
 
@@ -30,7 +30,7 @@ class BandwidthTypeTest(TembaTest):
         self.assertEqual(response.request["PATH_INFO"], reverse("orgs.org_bandwidth_international_connect"))
 
         # attach a Bandwidth accont to the org
-        self.org.config = {BWI_ACCOUNT_SID: "bw-account-sid", BWI_ACCOUNT_TOKEN: "bw-account-token"}
+        self.org.config = {BWI_USERNAME: "bwi-username", BWI_PASSWORD: "bwi-password"}
         self.org.save()
 
         # hit the claim page, should now have a claim bandwidth link

--- a/temba/channels/types/bandwidth_international/views.py
+++ b/temba/channels/types/bandwidth_international/views.py
@@ -8,7 +8,7 @@ from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
 from smartmin.views import SmartFormView
 
-from temba.orgs.models import BWI_ACCOUNT_SID, BWI_APPLICATION_SID, BWI_USERNAME, BWI_PASSWORD
+from temba.orgs.models import BWI_SENDER, BWI_ENCODING, BWI_USERNAME, BWI_PASSWORD
 from temba.utils import analytics
 from ...models import Channel
 from ...views import (
@@ -38,7 +38,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         def clean(self):
             BWI_KEY = os.environ.get("BWI_KEY")
             if not BWI_KEY or len(BWI_KEY) == 0:
-                raise ValidationError(_("The environment variable BWI_KEY  must be a valid encryption key"))
+                raise ValidationError(_("The environment variable BWI_KEY must be a valid encryption key"))
 
             return self.cleaned_data
 
@@ -66,7 +66,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
     submit_button_name = "Save"
     success_url = "@channels.types.bandwidth_international.claim"
     field_config = dict(bw_account_sid=dict(label=""), bw_account_token=dict(label=""))
-    success_message = "Bandwidth Account successfully connected."
+    success_message = "Bandwidth International account successfully connected."
 
     def form_valid(self, form):
         bwi_encoding = form.cleaned_data["bwi_encoding"]
@@ -80,7 +80,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
 
     def claim_number(self, user, phone_number, country, role):
         analytics.track(user.username, "temba.channel_claim_bandwidth_international",
-                        properties=dict(account_sid=BWI_ACCOUNT_SID))
+                        properties=dict(bwi_sender=BWI_SENDER))
         return None
 
     def create_channel(self, user, role, encoding, bwi_sender):
@@ -89,8 +89,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         callback_domain = org.get_brand_domain()
 
         config = {
-            Channel.CONFIG_APPLICATION_SID: org.config.get(BWI_APPLICATION_SID, None),
-            Channel.CONFIG_ACCOUNT_SID: org.config[BWI_ACCOUNT_SID],
             Channel.CONFIG_USERNAME: org.config.get(BWI_USERNAME, None),
             Channel.CONFIG_PASSWORD: org.config.get(BWI_PASSWORD, None),
             Channel.CONFIG_ENCODING: encoding,

--- a/templates/orgs/org_bandwidth_account.haml
+++ b/templates/orgs/org_bandwidth_account.haml
@@ -14,7 +14,7 @@
 
 -block summary
   -if object.is_connected_to_bandwidth
-    Connected to Bandwidth Account {{channel.name}}
+    Connected to Bandwidth Account - {{bw_account_sid}}
   -else
     Disconnected from Bandwidth
 

--- a/templates/orgs/org_bandwidth_international_account.haml
+++ b/templates/orgs/org_bandwidth_international_account.haml
@@ -14,9 +14,9 @@
 
 -block summary
   -if object.is_connected_to_bandwidth_international
-    Connected to Bandwidth International Account {{account_sid}}
+    Connected to Bandwidth International Account - {{bwi_username}}
   -else
-    Disconnected from Bandwidth International Account {{account_sid}}
+    Disconnected from Bandwidth International Account
 
 -block post-form
   -if object.is_connected_to_bandwidth_international

--- a/templates/orgs/org_bandwidth_international_connect.haml
+++ b/templates/orgs/org_bandwidth_international_connect.haml
@@ -13,7 +13,7 @@
 -block pre-form
   .connect-help
     %p
-      To connect your Bandwidth International Account you will need to provide your Bandwidth dashboard username and password, account ID, and application SID.
+      To connect your Bandwidth International Account you will need to provide your Username and Password.
 
     %p
       All of these values can be found by logging into your <a target="bandwidth" href="https://dashboard.bandwidth.com">Bandwidth Dashboard page</a>.


### PR DESCRIPTION
BWI account settings code tweaked to remove Account and App SIDs from its settings as only User/Pw is needed to connect to the BWI account.  This fixes most of the issues remaining in the https://github.com/istresearch/rapidpro/pull/62/ PR.  Last thing I have yet to figure out is to populate the user/pw fields with the decrypted information when you go back to edit the channel config.

Also, to test an actual BWI send/receive to ensure my changes didn't dork anything else up that was already working.