### PR TITLE
postmaster - Schemes field updates

### DIFF
--- a/static/less/style.less
+++ b/static/less/style.less
@@ -3,6 +3,9 @@
 @import "legacy";
 @import "formax";
 
+.control-group.field_schemes  {
+  width: 366px;
+}
 
 .btn-alert {
   .btn-colored(@color-alert-error, @color-font-white);

--- a/temba/channels/types/postmaster/type.py
+++ b/temba/channels/types/postmaster/type.py
@@ -1,10 +1,24 @@
-
 from django.utils.translation import ugettext_lazy as _
 
 from temba.channels.types.postmaster.views import ClaimView
-from temba.contacts.models import TEL_SCHEME
+
+from temba.utils.fields import SelectWidget
+from .. import TYPES
 
 from ...models import ChannelType
+from ...views import TYPE_UPDATE_FORM_CLASSES, UpdateChannelForm
+
+
+class UpdatePostmasterForm(UpdateChannelForm):
+
+    class Meta(UpdateChannelForm.Meta):
+        fields = "name", "address", "schemes"
+        config_fields = ["schemes", ]
+        readonly = ("address",)
+        helps = {"schemes": _("The Chat Mode that Postmaster will operate under.")}
+        labels = {"schemes": _("Chat Mode")}
+        from temba.channels.types.postmaster.views import ClaimView as ClaimView
+        widgets = {"schemes": SelectWidget(choices=ClaimView.Form.CHAT_MODE_CHOICES, attrs={"style": "width:360px"})}
 
 
 class PostmasterType(ChannelType):
@@ -24,8 +38,11 @@ class PostmasterType(ChannelType):
     )
     claim_view = ClaimView
 
-    schemes = [TEL_SCHEME]
+    schemes = None
+    _scheme = schemes
     max_length = 1600
+
+    update_form = UpdatePostmasterForm
 
     def deactivate(self, channel):
         number_update_args = dict()
@@ -35,3 +52,15 @@ class PostmasterType(ChannelType):
 
         if channel.supports_ivr():
             number_update_args["voice_application_sid"] = ""
+
+    @property
+    def schemes(self):
+        for type in TYPES:
+            if self._scheme is not None and type.name.lower() == self._scheme.lower():
+                self.update_form = TYPE_UPDATE_FORM_CLASSES.get(type.code)
+        return self._scheme
+
+    @schemes.setter
+    def set_schemes(self, value):
+        self.schemes = _scheme = value
+

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -10,7 +10,8 @@ from django.urls import reverse
 from temba.utils import analytics
 from django.utils.translation import ugettext_lazy as _
 
-
+from .. import TYPES
+from ..telegram import TelegramType
 from ...models import Channel
 from ...views import (
     ALL_COUNTRIES,
@@ -25,7 +26,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
     uuid = None
 
     class Form(ClaimViewMixin.Form):
-
         CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")), ("SMS", _("SMS")))
         pm_receiver_id = forms.CharField(label="You must provide a Receiver ID", help_text=_("Postmaster Receiver ID"))
         pm_chat_mode = forms.ChoiceField(label="Postmaster Chat Mode", help_text=_("Postmaster Chat Mode"),
@@ -116,9 +116,12 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             Channel.CONFIG_CALLBACK_DOMAIN: callback_domain,
         }
 
+        import temba.contacts.models as Contacts
+        schemes = [getattr(Contacts, '{}_SCHEME'.format(dict(ClaimView.Form.CHAT_MODE_CHOICES)[pm_chat_mode]).upper())]
+
         channel = Channel.create(
-            org, user, "US", self.code, name=pm_receiver_id, address=pm_receiver_id, role=role, config=config,
-            uuid=self.uuid
+            org, user, None, self.code, name=pm_receiver_id, address=pm_receiver_id, role=role, config=config,
+            uuid=self.uuid, schemes=schemes
         )
 
         analytics.track(user.username, "temba.channel_claim_postmaster", properties=dict(number=pm_receiver_id))

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -10,8 +10,7 @@ from django.urls import reverse
 from temba.utils import analytics
 from django.utils.translation import ugettext_lazy as _
 
-from .. import TYPES
-from ..telegram import TelegramType
+from django.conf import settings
 from ...models import Channel
 from ...views import (
     ALL_COUNTRIES,
@@ -26,7 +25,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
     uuid = None
 
     class Form(ClaimViewMixin.Form):
-        CHAT_MODE_CHOICES = (("WA", _("WhatsApp")), ("TG", _("Telegram")), ("SMS", _("SMS")))
+        CHAT_MODE_CHOICES = getattr(settings, "CHAT_MODE_CHOICES", ())
         pm_receiver_id = forms.CharField(label="You must provide a Receiver ID", help_text=_("Postmaster Receiver ID"))
         pm_chat_mode = forms.ChoiceField(label="Postmaster Chat Mode", help_text=_("Postmaster Chat Mode"),
                                          choices=CHAT_MODE_CHOICES)


### PR DESCRIPTION
The edit channel page should now provide a dropdown that allows you to also update the scheme.

1. Navigate to: channels/types/postmaster/claim
2. Create a postmaster channel. 
3. Check the postgres database channels_channel table to ensure that the newly created channels schema is properly set: `select id, channel_type, schemes  from channels_channel where channel_type = 'PSM' and is_active is true;`
4. Now navigate to the channel's update page ex (channels/channel/update/[channel_id]/).
<img width="550" alt="Screen Shot 2020-03-05 at 12 31 34 PM" src="https://user-images.githubusercontent.com/6886738/76101473-7c1c7c80-5f9c-11ea-97b9-5bbe0eea5148.png">

<img width="647" alt="Screen Shot 2020-03-05 at 12 31 30 PM" src="https://user-images.githubusercontent.com/6886738/76101237-1af4a900-5f9c-11ea-8a9e-1bf12bceb65e.png">

5. Modify the scheme and save the changes.
6. Verify in the postgres channels_channel table that the channels scheme has been updated: `select id, channel_type, schemes  from channels_channel where channel_type = 'PSM' and is_active is true;`