### PR TITLE
P4-801 - Remove 'Enable Bulk Sending' from the Channel Options

### DIFF
--- a/templates/channels/channel_read_list.haml
+++ b/templates/channels/channel_read_list.haml
@@ -65,9 +65,6 @@
                   %a.btn.btn-secondary.org-button.posterize{href:"{% url 'channels.channel_create_caller' %}?channel={{channel.pk}}"}
                     -trans "Enable Voice"
 
-                -if not sender.is_delegate_sender
-                  %a.btn.btn-secondary.org-button{href:'{% url "channels.channel_bulk_sender_options" %}?channel={{channel.pk}}'}
-                    -trans "Enable Bulk Sending"
 
           .channel-roles
                 -for delegate_channel in channel.get_delegate_channels


### PR DESCRIPTION
just removing the enable bulk sending button from the orgs/home page by removing it from the read_list.

To test, add a channel that supports bulk sending such as an android device.

Before:
<img width="1666" alt="Screen Shot 2020-03-17 at 2 50 40 PM" src="https://user-images.githubusercontent.com/6886738/76891073-c7694180-685e-11ea-9ece-3f22fe999a7a.png">

After:
<img width="1652" alt="Screen Shot 2020-03-17 at 2 52 05 PM" src="https://user-images.githubusercontent.com/6886738/76891162-e8319700-685e-11ea-9f25-4c9f650d4842.png">

