### PR TITLE
P4-1383 - Bug - removing a channel redirects to the wrong page

### DIFF
--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -2883,8 +2883,8 @@ class OrgCRUDL(SmartCRUDL):
         success_url = "@orgs.org_home"
 
         class BandwidthKeys(forms.ModelForm):
-            bwi_username = forms.CharField(max_length=128, label=_("Username"), required=True)
-            bwi_password = forms.CharField(max_length=128, label=_("Password"), required=True,
+            bwi_username = forms.CharField(max_length=128, label=_("Username"), required=False)
+            bwi_password = forms.CharField(max_length=128, label=_("Password"), required=False,
                     widget=forms.PasswordInput(render_value=True)
             )
             disconnect = forms.CharField(widget=forms.HiddenInput, max_length=6, required=True)
@@ -2918,7 +2918,7 @@ class OrgCRUDL(SmartCRUDL):
             bwi_key = os.environ.get("BWI_KEY")
             initial[str.lower(BWI_USERNAME)] = AESCipher(bwi_username, bwi_key).decrypt()
             initial[str.lower(BWI_PASSWORD)] = AESCipher(bwi_password, bwi_key).decrypt()
-            initial["disconnect"] = "false"
+            initial["disconnect"] = bool(self.request.POST.get("disconnect"))
             return initial
 
         def get_context_data(self, **kwargs):

--- a/templates/orgs/org_bandwidth_account.haml
+++ b/templates/orgs/org_bandwidth_account.haml
@@ -42,6 +42,7 @@
         Connect Bandwidth
 
 -block extra-script
+  {{block.super}}
   :javascript
     function confirmBandwidthDisconnect() {
       removalConfirmation("disconnect-bandwidth", "Disconnect");

--- a/templates/orgs/org_bandwidth_international_account.haml
+++ b/templates/orgs/org_bandwidth_international_account.haml
@@ -19,19 +19,19 @@
     Disconnected from Bandwidth International Account
 
 -block post-form
-  -if object.is_connected_to_bandwidth_international
+  -if object.is_connected_to_bandwidth_international and request.META.HTTP_X_FORMAX
     If you no longer want it connected, you can
-    %a{href:'javascript:confirmBandwidthDisconnect();'}
+    %a{href:'javascript:confirmBandwidthInternationalDisconnect();'}
       disconnect your Bandwidth International Account
 
   - if org_perms.channels.channel_delete
-    .disconnect-bandwidth.hide
+    .disconnect-bandwidth-international.hide
       .title
-        -trans "Disconnect Bandwidth"
+        -trans "Disconnect Bandwidth International"
       .body
         -blocktrans
-          Disconnecting your Bandwidth account will also remove any Bandwidth channels connected to it. Are you sure you want to proceed?
-    %a#disconnect-bandwidth-form.posterize{href:'{% url "orgs.org_bandwidth_international_account" %}?disconnect=true&channel_id={{channel.id}}'}
+          Disconnecting your Bandwidth International account will also remove any Bandwidth International channels connected to it. Are you sure you want to proceed?
+    %a#disconnect-bandwidth-international-form.posterize{href:'{% url "orgs.org_bandwidth_international_account" %}?disconnect=true&channel_id={{channel.id}}'}
 
 -block form-buttons
   .form-actions
@@ -42,7 +42,8 @@
         Connect Bandwidth
 
 -block extra-script
+  {{block.super}}
   :javascript
-    function confirmBandwidthDisconnect() {
-      removalConfirmation("disconnect-bandwidth", "Disconnect");
+    function confirmBandwidthInternationalDisconnect() {
+      removalConfirmation("disconnect-bandwidth-international", "Disconnect");
     }

--- a/templates/orgs/org_postmaster_account.haml
+++ b/templates/orgs/org_postmaster_account.haml
@@ -42,6 +42,7 @@
         Connect Bandwidth
 
 -block extra-script
+  {{block.super}}
   :javascript
     function confirmBandwidthDisconnect() {
       removalConfirmation("disconnect-bandwidth", "Disconnect");


### PR DESCRIPTION
1. Create a BWI account using a valid BWI dashboard username and password (sorry about that last time, @baracudda). 
<img width="762" alt="Screen Shot 2020-03-31 at 3 08 41 PM" src="https://user-images.githubusercontent.com/6886738/78065941-12587e00-7362-11ea-8332-cf5e21295734.png">

2. Create a BWI channel by providing a sender name and sender type.
<img width="698" alt="Screen Shot 2020-03-31 at 3 08 58 PM" src="https://user-images.githubusercontent.com/6886738/78065929-0d93ca00-7362-11ea-8756-b14c2fcf783d.png">

3. Navigate to the org/home page and locate the bandwidth international account (not the channel).
<img width="935" alt="Screen Shot 2020-03-31 at 3 09 37 PM" src="https://user-images.githubusercontent.com/6886738/78065912-07055280-7362-11ea-847a-e2630693e9b3.png">

4. Click on the account to expand the credentials form and then click on the "_disconnect your bandwidth international account_" link.
<img width="774" alt="Screen Shot 2020-03-31 at 3 09 50 PM" src="https://user-images.githubusercontent.com/6886738/78065902-0076db00-7362-11ea-9ea2-8c9893d1e07d.png">

5. Click the "disconnect" button on the dialog
<img width="1128" alt="Screen Shot 2020-03-31 at 3 09 58 PM" src="https://user-images.githubusercontent.com/6886738/78066036-3a47e180-7362-11ea-8e97-98f39479cba7.png">

**Expected Result:**
The account will be unlinked from the Org and you will be redirected to the Org home screen.
