### PR TITLE
P4 1357

### DIFF
--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -45,7 +45,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
                 channel = None
                 channels = Channel.objects.filter(channel_type=ClaimView.code, is_active=True)
                 for ch in channels:
-                    if ch.config.get('chat_mode') == pm_chat_mode:
+                    if ch.config.get('chat_mode') == pm_chat_mode and ch.org.id == org.id:
                         channel = ch
                         break
 

--- a/temba/ext/api/v2/views.py
+++ b/temba/ext/api/v2/views.py
@@ -223,6 +223,7 @@ class ExtChannelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIVi
             "slug": "channel-write",
             "fields": [
                 {"name": "type", "required": True, "help": "The type of channel you want to create"},
+                {"name": "org", "required": True, "help": "The Org that the channel will be created in"},
                 {"name": "params[]", "required": True, "help": "A list of parameter name/value mappings that are "
                                                                "acceptable to the target channel type, as defined "
                                                                "in the channels claim view Form."},


### PR DESCRIPTION
**Channel creation API endpoint.**

/ext/api/v2/channels.json?type=PSM&pm_chat_mode=MODE&pm_device_id=ID&org=ORGID

**Example curl request:**
> curl -vvv -H 'Cache-Control: no-cache'  -H "Authorization: Token e90c28b089cfc9542a1351d8f36619f5a70e1771" -X POST "https://83f83d51.ngrok.io/engage/ext/api/v2/channels.json?type=PSM&pm_chat_mode=SMS&pm_device_id=weezer4&org=2"

**Expected result:**

> {"uuid":"143da693-2989-4989-aefc-9c84afacae0f","name":"weezer4","address":"weezer4","country":"","device":null,"last_seen":"2020-04-01T14:39:38.625537Z","created_on":"2020-04-01T14:39:38.624506Z","config":"{'device_id': 'weezer4', 'chat_mode': 'SMS', 'callback_domain': '83f83d51.ngrok.io', 'org_id': 2}"}

**Expected result on failure (_already exists_):**

> {"uuid":null,"name":null,"address":null,"country":"","device":null,"last_seen":null,"created_on":null,"config":"{\"__all__\": [{\"message\": \"A chat mode for SMS already exists for the neworg org\", \"code\": \"\"}]}"}

_Notice the error message is moved into the channel.config field, all other fields are null if the creation fails_

