### PR TITLE
P4-1356 - Engage - New API endpoint to remove Postmaster channels

### DIFF
--- a/temba/ext/api/v2/views.py
+++ b/temba/ext/api/v2/views.py
@@ -14,15 +14,24 @@ from temba.ext.api.models import ExtAPIPermission
 from temba.api.models import SSLPermission
 from temba.api.v2.serializers import (ReadSerializer, WriteSerializer)
 from temba.orgs.models import Org
+import json
 
 class ExtChannelReadSerializer(ReadSerializer):
     country = serializers.SerializerMethodField()
     device = serializers.SerializerMethodField()
     created_on = serializers.DateTimeField(default_timezone=pytz.UTC)
     last_seen = serializers.DateTimeField(default_timezone=pytz.UTC)
+    config = serializers.SerializerMethodField()
 
     def get_country(self, obj):
         return str(obj.country) if hasattr(obj, 'country') else None
+
+    def get_config(self, obj):
+        if not hasattr(obj, 'config'):
+            return None
+
+        return obj.config
+
 
     def get_device(self, obj):
         if hasattr(obj, 'channel_type') and obj.channel_type != Channel.TYPE_ANDROID:


### PR DESCRIPTION
**Note:** _Included in this PR is a commit that changes the serialization of the config object into a nested json object instead of json string._

Removing channels via the Extended REST API via CURL.
**Method:** DELETE
**Required Headers:** "Authorization: Token zyxponmlyabadabadoo"
**Path:** /ext/api/v2/channels.json?uuid=UUID_OF_CHANNEL_TO_BE_DELETED

**Example:**
`curl -vvv -H "accept: application/json" -H 'Cache-Control: no-cache' -H "Authorization: Token e90c28b089cfc9542a1351d8f36619f5a70e1771" -X DELETE "https://83f83d51.ngrok.io/engage/ext/api/v2/channels.json?uuid=993f1212-db36-0528-cd32-e0f93a75fad4"`

**Results:**
1) If the channel exists and is released OR if the channel exists yet an exception is thrown while attempting to release, you will receive a response object:
`{"name": "Device Name", "id": 101, "uuid":"993f1212-db36-0528-cd32-e0f93a75fad4", "is_active":false, "response":{"status":INTEGER_STATUS_CODE, "errors" ["an array of errors if exeptions were thrown"]}`

2) Example response with an exception: 
`{"name":"Android SDK built for x86","id":15007,"uuid":"993f1212-db36-0528-cd32-e0f93a75fad4","is_active":false,"response":{"status":500,"errors":["A very specific bad thing happened."]}}`

3) If the channel does not exist then a 404 will be returned with a response object containing a detail field:
`{"detail":"Not found."}`