### PR TITLE
P4 1399 - Removing flow editor choice from new flow dialog (develop)

### DIFF
--- a/temba/flows/views.py
+++ b/temba/flows/views.py
@@ -399,15 +399,6 @@ class FlowCRUDL(SmartCRUDL):
                 ),
             )
 
-            use_new_editor = forms.TypedChoiceField(
-                label=_("New Editor (Beta)"),
-                help_text=_("Use new editor when authoring this flow"),
-                choices=((1, "Yes"), (0, "No")),
-                initial=0,
-                required=False,
-                coerce=int,
-            )
-
             def __init__(self, user, branding, *args, **kwargs):
                 super().__init__(*args, **kwargs)
                 self.user = user
@@ -430,7 +421,7 @@ class FlowCRUDL(SmartCRUDL):
 
             class Meta:
                 model = Flow
-                fields = ("name", "keyword_triggers", "flow_type", "base_language", "use_new_editor")
+                fields = ("name", "keyword_triggers", "flow_type", "base_language")
 
         form_class = FlowCreateForm
         success_url = "uuid@flows.flow_editor"


### PR DESCRIPTION
- [x] Code review complete
- [x] Testing Complete

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
The new flow editor is used regardless of selection. This PR removes the form filed from the dialog.

#### Release Note
<Concise sentence describing change>The new flow editor is used regardless of selection, so removing the form field from the dialog.

#### Breaking Changes
<Description for Techops of how to handle changes>None.

## Testing and Verification

1. Go to https://engage.dev.istresearch.com/flow/
2. Create a new flow. The dialog for a new flow should no longer contain a drop down for the Flow Editor Type.
3. Validate your new flow open in the new flow editor.

