### PR TITLE
P4-1457 - Engage - New Postmaster Channel Schemes

### DIFF
--- a/temba/channels/types/postmaster/type.py
+++ b/temba/channels/types/postmaster/type.py
@@ -5,7 +5,7 @@ from temba.channels.types.postmaster.views import ClaimView
 from temba.utils.fields import SelectWidget
 from .. import TYPES
 
-from ...models import ChannelType
+from ...models import ChannelType, Channel
 from ...views import TYPE_UPDATE_FORM_CLASSES, UpdateChannelForm
 
 
@@ -20,6 +20,10 @@ class UpdatePostmasterForm(UpdateChannelForm):
         from temba.channels.types.postmaster.views import ClaimView as ClaimView
         widgets = {"schemes": SelectWidget(choices=ClaimView.Form.CHAT_MODE_CHOICES, attrs={"style": "width:360px"})}
 
+    def save(self, commit=True):
+        config = self.object.config
+        config[Channel.CONFIG_CHAT_MODE] = self.cleaned_data['schemes'][0]
+        return super().save(commit=commit)
 
 class PostmasterType(ChannelType):
     """

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -118,7 +118,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         }
 
         import temba.contacts.models as Contacts
-        schemes = [getattr(Contacts, '{}_SCHEME'.format(dict(ClaimView.Form.CHAT_MODE_CHOICES)[pm_chat_mode]).upper())]
+        schemes = [getattr(Contacts, 'PM_{}_SCHEME'.format(dict(ClaimView.Form.CHAT_MODE_CHOICES)[pm_chat_mode]).upper())]
 
         channel = Channel.create(
             org, user, None, self.code, name=pm_device_id, address=pm_device_id, role=role, config=config,

--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -67,6 +67,12 @@ SMS_SCHEME = "sms"
 
 FACEBOOK_PATH_REF_PREFIX = "ref:"
 
+# Postmaster schemes
+PM_WHATSAPP_SCHEME = "pm_whatsapp"
+PM_TELEGRAM_SCHEME = "pm_telegram"
+PM_SIGNAL_SCHEME = "pm_signal"
+PM_LINE_SCHEME = "pm_line"
+
 # Scheme, Label, Export/Import Header, Context Key
 URN_SCHEME_CONFIG = (
     (TEL_SCHEME, _("Phone number"), "tel_e164"),
@@ -84,6 +90,10 @@ URN_SCHEME_CONFIG = (
     (WHATSAPP_SCHEME, _("WhatsApp identifier"), WHATSAPP_SCHEME),
     (FRESHCHAT_SCHEME, _("Freshchat identifier"), FRESHCHAT_SCHEME),
     (SMS_SCHEME, _("SMS identifier"), SMS_SCHEME),
+    (PM_WHATSAPP_SCHEME, _("Postmaster WhatsApp identifier"), PM_WHATSAPP_SCHEME),
+    (PM_TELEGRAM_SCHEME, _("Postmaster Telegram identifier"), PM_TELEGRAM_SCHEME),
+    (PM_SIGNAL_SCHEME, _("Postmaster Signal identifier"), PM_SIGNAL_SCHEME),
+    (PM_LINE_SCHEME, _("Postmaster Line identifier"), PM_LINE_SCHEME),
 )
 
 


### PR DESCRIPTION
Introducing New Postmaster specific Channel Schemes for contacts.

The contact's update form now has 4 additional schemes:
```
(PM_WHATSAPP_SCHEME, _("Postmaster WhatsApp identifier"), PM_WHATSAPP_SCHEME),
(PM_TELEGRAM_SCHEME, _("Postmaster Telegram identifier"), PM_TELEGRAM_SCHEME),
(PM_SIGNAL_SCHEME, _("Postmaster Signal identifier"), PM_SIGNAL_SCHEME),
(PM_LINE_SCHEME, _("Postmaster Line identifier"), PM_LINE_SCHEME),
```
<img width="891" alt="Screen Shot 2020-04-14 at 9 13 54 AM" src="https://user-images.githubusercontent.com/6886738/79229078-75511700-7e30-11ea-8e36-4f6c16e8169b.png">

This PR also includes a fix to the Postmaster channel update server-side submission logic where we now update the chat_mode based on the scheme:
```
    def save(self, commit=True):
        config = self.object.config
        config[Channel.CONFIG_CHAT_MODE] = self.cleaned_data['schemes'][0]
        return super().save(commit=commit)
```

1. To test, create a Postmaster channel with any chat_mode. 
2. Confirm in postgres that the channels.channel.config JSON has the chat_mode correctly configured. 
3. Now go and edit the channel and change the chat_mode. 
4. Confirm in postgres that the chat_mode has successfully been updated.