### PR TITLE
P4-1457 - Fixing postmaster sms scheme bug

### DIFF
--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -118,8 +118,11 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         }
 
         import temba.contacts.models as Contacts
-        schemes = [getattr(Contacts, 'PM_{}_SCHEME'.format(dict(ClaimView.Form.CHAT_MODE_CHOICES)[pm_chat_mode]).upper())]
-
+        prefix = 'PM_'
+        if pm_chat_mode == 'SMS':
+            prefix = ''
+        schemes = [getattr(Contacts,
+                           '{}{}_SCHEME'.format(prefix, dict(ClaimView.Form.CHAT_MODE_CHOICES)[pm_chat_mode]).upper())]
         channel = Channel.create(
             org, user, None, self.code, name=pm_device_id, address=pm_device_id, role=role, config=config,
             uuid=self.uuid, schemes=schemes


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

P4-1457 - Fixing postmaster sms scheme bug

## Summary
There was a bug caused by the lack of the SMS_SCHEME having a PM_ prefix. 

#### Release Note
Added a special condition so that if the chat mode is SMS then we will use the built in SMS scheme. Otherwise we will use the PM_ specific schemes.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Do this: `$ run-this.sh`
2. Look for this.
3. Clean up with this command
