### PR TITLE
P4-1355 - Postmaster New Channel page to display claim code

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -282,6 +282,8 @@ class Channel(TembaModel):
     CONFIG_DEVICE_ID = "device_id"
     CONFIG_DEVICE_NAME = "device_name"
     CONFIG_CHAT_MODE = "chat_mode"
+    CONFIG_CLAIM_CODE = "claim_code"
+    CONFIG_ORG_ID = "org_id"
     CONFIG_CHANNEL_MID = "channel_mid"
     CONFIG_FCM_ID = "FCM_ID"
     CONFIG_MAX_LENGTH = "max_length"

--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -280,6 +280,7 @@ class Channel(TembaModel):
     CONFIG_SECRET = "secret"
     CONFIG_CHANNEL_ID = "channel_id"
     CONFIG_DEVICE_ID = "device_id"
+    CONFIG_DEVICE_NAME = "device_name"
     CONFIG_CHAT_MODE = "chat_mode"
     CONFIG_CHANNEL_MID = "channel_mid"
     CONFIG_FCM_ID = "FCM_ID"

--- a/temba/channels/types/postmaster/postoffice.py
+++ b/temba/channels/types/postmaster/postoffice.py
@@ -1,0 +1,19 @@
+from django.conf import settings
+import requests
+import json
+
+
+def __init__(self, channel_type):
+    super().__init__(channel_type)
+
+
+def fetch_qr_code(org):
+    server_url = getattr(settings, "POST_OFFICE_QR_URL", ())
+    api_key = getattr(settings, "POST_OFFICE_API_KEY", ())
+    data = json.dumps({"org_id": org.id, "org_name": org.name})
+    if server_url is not None and api_key is not None:
+        r = requests.post(server_url, headers={"x-api-key": "{}".format(api_key)}, data=data)
+        if r.status_code == 200:
+            return json.loads(r.content)
+    return None
+

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -139,7 +139,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         }
 
         import temba.contacts.models as Contacts
-        prefix = ''
+        prefix = 'PM_'
         if chat_mode == 'SMS':
             prefix = ''
 

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -143,8 +143,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         if chat_mode == 'SMS':
             prefix = ''
 
-        kwargs = {'claim_code': claim_code}
-
         schemes = [getattr(Contacts,
                            '{}{}_SCHEME'.format(prefix, dict(ClaimView.Form.CHAT_MODE_CHOICES)[chat_mode]).upper())]
         channel = Channel.create(

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -147,7 +147,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
                            '{}{}_SCHEME'.format(prefix, dict(ClaimView.Form.CHAT_MODE_CHOICES)[chat_mode]).upper())]
         channel = Channel.create(
             org, user, None, self.code, name=device_name, address=device_id, role=role, config=config,
-            uuid=self.uuid, schemes=schemes, claim_code=claim_code
+            uuid=self.uuid, schemes=schemes
         )
 
         analytics.track(user.username, "temba.channel_claim_postmaster", properties=dict(number=device_id))

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -34,7 +34,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         chat_mode = forms.ChoiceField(label="Postmaster Chat Mode", help_text=_("Postmaster Chat Mode"),
                                          choices=CHAT_MODE_CHOICES)
         claim_code = forms.CharField(label="Claim Code", help_text=_("Claim Code"))
-        org_id = forms.CharField(label="Org ID", help_text=_("Org ID"))
+        org_id = forms.IntegerField(label="Org ID", help_text=_("Org ID"))
 
         def clean(self):
 

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -106,7 +106,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         device_id = form.cleaned_data["device_id"]
         device_name = form.cleaned_data["device_name"]
         chat_mode = form.cleaned_data["chat_mode"]
-        claim_code = form.cleaned_data["claim_code", None]
+        claim_code = form.cleaned_data["claim_code"]
 
         channel = self.create_channel(self.request.user, Channel.ROLE_SEND + Channel.ROLE_CALL, device_id,
                                       device_name, chat_mode, claim_code)

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -55,7 +55,8 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
                 channel = None
                 channels = Channel.objects.filter(channel_type=ClaimView.code, is_active=True)
                 for ch in channels:
-                    if ch.config.get('chat_mode') == chat_mode and ch.org.id == org.id:
+                    if ch.config.get('chat_mode') == chat_mode and ch.config.get('device_id') == device_id and \
+                            ch.org.id == org.id:
                         channel = ch
                         break
 

--- a/temba/ext/api/v2/views.py
+++ b/temba/ext/api/v2/views.py
@@ -152,7 +152,7 @@ class ExtChannelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIVi
 
     Example:
 
-        POST /ext/api/v2/channels.json?type=PSM&pm_chat_mode=WA&pm_device_id=weezer
+        POST /ext/api/v2/channels.json?type=PSM&chat_mode=WA&device_id=weezer
 
     You will receive a Channel object as a response if successful:
 

--- a/temba/ext/api/v2/views.py
+++ b/temba/ext/api/v2/views.py
@@ -197,6 +197,10 @@ class ExtChannelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIVi
         if address:
             queryset = queryset.filter(address=address)
 
+        claim_code = params.get("claim_code")
+        if claim_code:
+            queryset = queryset.filter(claim_code=claim_code)
+
         c_type = params.get("type")
         if c_type:
             queryset = queryset.filter(channel_type=c_type)

--- a/temba/ext/api/v2/views.py
+++ b/temba/ext/api/v2/views.py
@@ -199,7 +199,7 @@ class ExtChannelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIVi
 
         claim_code = params.get("claim_code")
         if claim_code:
-            queryset = queryset.filter(claim_code=claim_code)
+            queryset = queryset.filter(config__contains='"claim_code": "{}"'.format(claim_code))
 
         c_type = params.get("type")
         if c_type:

--- a/temba/orgs/models.py
+++ b/temba/orgs/models.py
@@ -758,9 +758,9 @@ class Org(SmartModel):
         self.modified_by = user
         self.save(update_fields=("config", "modified_by", "modified_on"))
 
-    def connect_postmaster(self, pm_receiver_id, pm_chat_mode, user):
-        self.config.update({Org.CONFIG_POSTMASTER_RECEIVER_ID: pm_receiver_id,
-                            Org.CONFIG_POSTMASTER_CHATMODE: pm_chat_mode})
+    def connect_postmaster(self, receiver_id, chat_mode, user):
+        self.config.update({Org.CONFIG_POSTMASTER_RECEIVER_ID: receiver_id,
+                            Org.CONFIG_POSTMASTER_CHATMODE: chat_mode})
         self.modified_by = user
         self.save(update_fields=("config", "modified_by", "modified_on"))
 

--- a/temba/orgs/views.py
+++ b/temba/orgs/views.py
@@ -768,17 +768,17 @@ class OrgCRUDL(SmartCRUDL):
 
     class PostmasterConnect(ModalMixin, InferOrgMixin, OrgPermsMixin, SmartFormView):
         class PostmasterConnectForm(forms.Form):
-            pm_receiver_id = forms.CharField(label="Device ID", help_text=_("Your Postmaster Device ID"))
-            pm_chat_mode = forms.CharField(label="Chat Mode", help_text=_("Your Postmaster Chat Mode"))
+            receiver_id = forms.CharField(label="Device ID", help_text=_("Your Postmaster Device ID"))
+            chat_mode = forms.CharField(label="Chat Mode", help_text=_("Your Postmaster Chat Mode"))
 
             def clean(self):
-                pm_receiver_id = self.cleaned_data.get("pm_receiver_id", None)
-                pm_chat_mode = self.cleaned_data.get("pm_chat_mode", None)
+                receiver_id = self.cleaned_data.get("receiver_id", None)
+                chat_mode = self.cleaned_data.get("chat_mode", None)
 
-                if not pm_receiver_id:
+                if not receiver_id:
                     raise ValidationError(_("You must enter your Postmaster Device ID"))
 
-                if not pm_chat_mode:
+                if not chat_mode:
                     raise ValidationError(_("You must enter your Postmaster Chat Mode"))
 
                 return self.cleaned_data
@@ -786,15 +786,15 @@ class OrgCRUDL(SmartCRUDL):
         form_class = PostmasterConnectForm
         submit_button_name = "Save"
         success_url = "@channels.types.postmaster.claim"
-        field_config = dict(pm_receiver_id=dict(label=""), pm_chat_mode=dict(label=""))
+        field_config = dict(receiver_id=dict(label=""), chat_mode=dict(label=""))
         success_message = "Postmaster Account successfully connected."
 
         def form_valid(self, form):
-            pm_receiver_id = form.cleaned_data["pm_receiver_id"]
-            pm_chat_mode = form.cleaned_data["pm_chat_mode"]
+            receiver_id = form.cleaned_data["receiver_id"]
+            chat_mode = form.cleaned_data["chat_mode"]
 
             org = self.get_object()
-            org.connect_postmaster(pm_receiver_id, pm_chat_mode, self.request.user)
+            org.connect_postmaster(receiver_id, chat_mode, self.request.user)
             org.save()
 
             return HttpResponseRedirect(self.get_success_url())
@@ -803,27 +803,27 @@ class OrgCRUDL(SmartCRUDL):
         success_message = ""
 
         class PostmasterKeys(forms.ModelForm):
-            pm_receiver_id = forms.CharField(label="Device ID", help_text=_("Your Postmaster Device ID"))
-            pm_chat_mode = forms.CharField(label="Chat Mode", help_text=_("Your Postmaster Chat Mode"))
+            receiver_id = forms.CharField(label="Device ID", help_text=_("Your Postmaster Device ID"))
+            chat_mode = forms.CharField(label="Chat Mode", help_text=_("Your Postmaster Chat Mode"))
             disconnect = forms.CharField(widget=forms.HiddenInput, max_length=6, required=True)
 
             def clean(self):
                 super().clean()
                 if self.cleaned_data.get("disconnect", "false") == "false":
-                    pm_receiver_id = self.cleaned_data.get("pm_receiver_id", None)
-                    pm_chat_mode = self.cleaned_data.get("pm_chat_mode", None)
+                    receiver_id = self.cleaned_data.get("receiver_id", None)
+                    chat_mode = self.cleaned_data.get("chat_mode", None)
 
-                    if not pm_receiver_id:
+                    if not receiver_id:
                         raise ValidationError(_("You must enter your Postmaster Device ID"))
 
-                    if not pm_chat_mode:  # pragma: needs cover
+                    if not chat_mode:  # pragma: needs cover
                         raise ValidationError(_("You must enter your Postmaster Chat Mode"))
 
                 return self.cleaned_data
 
             class Meta:
                 model = Org
-                fields = ("pm_receiver_id", "pm_chat_mode", "disconnect")
+                fields = ("receiver_id", "chat_mode", "disconnect")
 
         form_class = PostmasterKeys
 
@@ -831,8 +831,8 @@ class OrgCRUDL(SmartCRUDL):
             initial = super().derive_initial()
             org = self.get_object()
             config = org.config
-            initial["pm_receiver_id"] = config.get(Org.CONFIG_POSTMASTER_RECEIVER_ID, "")
-            initial["pm_chat_mode"] = config.get(Org.CONFIG_POSTMASTER_CHAT_MODE, "")
+            initial["receiver_id"] = config.get(Org.CONFIG_POSTMASTER_RECEIVER_ID, "")
+            initial["chat_mode"] = config.get(Org.CONFIG_POSTMASTER_CHAT_MODE, "")
             initial["disconnect"] = "false"
             return initial
 
@@ -845,10 +845,10 @@ class OrgCRUDL(SmartCRUDL):
                 org.remove_postmaster_account(user)
                 return HttpResponseRedirect(reverse("orgs.org_home"))
             else:
-                pm_receiver_id = form.cleaned_data["pm_receiver_id"]
-                pm_chat_mode = form.cleaned_data["api_secret"]
+                receiver_id = form.cleaned_data["receiver_id"]
+                chat_mode = form.cleaned_data["api_secret"]
 
-                org.connect_nexmo(pm_receiver_id, pm_chat_mode, user)
+                org.connect_nexmo(receiver_id, chat_mode, user)
                 return super().form_valid(form)
 
         def get_context_data(self, **kwargs):
@@ -858,8 +858,8 @@ class OrgCRUDL(SmartCRUDL):
             client = org.get_nexmo_client()
             if client:
                 config = org.config
-                context["pm_receiver_id"] = config.get(Org.CONFIG_POSTMASTER_RECEIVER_ID, "")
-                context["pm_chat_mode"] = config.get(Org.CONFIG_POSTMASTER_CHAT_MODE, "")
+                context["receiver_id"] = config.get(Org.CONFIG_POSTMASTER_RECEIVER_ID, "")
+                context["chat_mode"] = config.get(Org.CONFIG_POSTMASTER_CHAT_MODE, "")
 
             return context
 

--- a/templates/channels/types/postmaster/claim.haml
+++ b/templates/channels/types/postmaster/claim.haml
@@ -6,12 +6,26 @@
 
   %h2.font_normalize.header-margin
     {{ title }}
+  %span
+    To register Postmaster, hit the SCAN QR Code button in the app.
 
-
--block pre-form
+-block fields
   -if po_qr and po_qr.qr_base64
-    %div{class:"pm-qr; float-right; inline-block; pull-right", style:"width: 800px;"}
-      %img{ src:"data:png;base64, {{po_qr.qr_base64}}" }
+    %div{class:"pm-qr;"}
+      %img{ src:"data:png;base64, {{po_qr.qr_base64}}" }{style:"padding-left: 110px; padding-bottom: 20px"}
+      %div{style:"padding-left: 100px; padding-bottom: 20px"}
+        %div
+          %code
+            Claim Code: {{po_qr.data.claim_code}}
+        %div
+          %code
+            Server: {{po_qr.data.server}}
+        %div
+          %code
+            API Key: {{po_qr.data.api_key}}
+
+
+-block form-buttons
 
 -block extra-script
   {{ block.super }}
@@ -21,4 +35,21 @@
       $("#id_country").select2();
     });
 
+    setInterval(
+    function pollUntilDone(url, interval, timeout) {
+
+      $.get('{% url "ext.api.v2.channels" %}?claim_code={{po_qr.data.claim_code}}', function(data) {
+        if (Array.isArray(data['results'])) {
+          window.location = '{% url "orgs.org_home" %}';
+        }
+      });
+    }, 5000);
+
+-block extra-style
+  {{ block.super }}
+
+  :css
+    .pm-qr {
+      width: 500px !important;
+    }
 

--- a/templates/channels/types/postmaster/claim.haml
+++ b/templates/channels/types/postmaster/claim.haml
@@ -1,0 +1,24 @@
+-extends "channels/channel_claim_form.html"
+-load i18n
+
+-block title
+  .medium-help.float-left{class:"{{ view.channel_type.icon }}"}
+
+  %h2.font_normalize.header-margin
+    {{ title }}
+
+
+-block pre-form
+  -if po_qr and po_qr.qr_base64
+    %div{class:"pm-qr; float-right; inline-block; pull-right", style:"width: 800px;"}
+      %img{ src:"data:png;base64, {{po_qr.qr_base64}}" }
+
+-block extra-script
+  {{ block.super }}
+
+  :javascript
+    $(function(){
+      $("#id_country").select2();
+    });
+
+

--- a/templates/channels/types/postmaster/claim.haml
+++ b/templates/channels/types/postmaster/claim.haml
@@ -38,8 +38,8 @@
     setInterval(
     function pollUntilDone(url, interval, timeout) {
 
-      $.get('{% url "ext.api.v2.channels" %}?claim_code={{po_qr.data.claim_code}}', function(data) {
-        if (Array.isArray(data['results'])) {
+      $.get('{% url "ext.api.v2.channels" %}.json?claim_code={{po_qr.data.claim_code}}', function(data) {
+        if (Array.isArray(data['results']) && data['results'].length > 0) {
           window.location = '{% url "orgs.org_home" %}';
         }
       });


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

https://istresearch.atlassian.net/browse/P4-1355

## Summary
New input fields for postmaster form creation along with the option to scan a QR code dynamically retrieved from the postoffice REST API.

#### Release Note
<Concise sentence describing change>Required.

#### Breaking Changes
<Description for Techops of how to handle changes, migrations, updates>None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1) Ensure that you have added valid postoffice api credentials to your settings.py
2) Standup the P4 Engage environment **that includes the latest Postoffice**
3) Navigate to *{subdir}*/channels/types/postmaster/claim 
4) Using the input fields, provide all required credentials and verify that the postoffice claim code, and postoffice server url are properly saved to the channels_channel.config field in Postgres.

1) Steps (1-3) above
2) Using a Postmaster device scan the QR code
3) Ensure that the QR provided values are valid.
4) Ensure that the *{subdir}*/channels/types/postmaster/claim  redirects to the newly created channels READ page.