### PR TITLE
P4-1518 - Add postmaster channel scheme as suffix to the name

### DIFF
--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -145,8 +145,11 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
 
         schemes = [getattr(Contacts,
                            '{}{}_SCHEME'.format(prefix, dict(ClaimView.Form.CHAT_MODE_CHOICES)[chat_mode]).upper())]
+        
+        name_with_scheme = '{} [{}]'.format(device_name, schemes[0])
+
         channel = Channel.create(
-            org, user, None, self.code, name=device_name, address=device_id, role=role, config=config,
+            org, user, None, self.code, name=name_with_scheme, address=device_id, role=role, config=config,
             uuid=self.uuid, schemes=schemes
         )
 


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Postmaster channel names were getting reused for each mode for a specific device. This led to confusion anywhere the names were used without any extra context of which channel was which mode. This PR appends the scheme used to the name, for example: `mydevice [pm_telegram]`

#### Release Note
Postmaster channel names will be appended with the channel scheme for easy identification. 

#### Breaking Changes
None

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: Required.
- **P4 Alerting**: Required.

## Testing and Verification

1. Initialize a full engage stack
2. Generate a claim code for postmaster on the new channel page, and connect the channel
3. For any active modes, all channels will be: `device_name [scheme]`. 

![Screen Shot 2020-05-08 at 9 00 02 AM](https://user-images.githubusercontent.com/25488234/81407956-57fb2a00-910a-11ea-80d7-44ac9c3eb04c.png)
