### PR TITLE
Fixing Flow' is not JSON serializable error when dependent flows are …

### DIFF
--- a/temba/ext/api/v2/views.py
+++ b/temba/ext/api/v2/views.py
@@ -243,7 +243,7 @@ class ExtChannelsEndpoint(ListAPIMixin, WriteAPIMixin, DeleteAPIMixin, BaseAPIVi
                 data["response"]["errors"] = e.args
                 dependent_flows = []
                 for flow in channel.dependent_flows.distinct():
-                    dependent_flows.append(flow)
+                    dependent_flows.append(flow.as_json())
                 data["response"]["dependent_flows"] = dependent_flows
             return Response(content_type="application/json", data=data, status=data["response"]["status"])
 


### PR DESCRIPTION
… present

# For the Reviewer
- [x] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
When deleting a channel that has dependent flows, prior to this fix you would receive a 500 error due to the Flow object not being JSON serializable. 

This fixes the issue by serializing the Flow via json.dumps.

#### Release Note
This fixes the issue by serializing the Flow via json.dumps.


#### Breaking Changes
N/W
## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification
When deleting a channel that has dependent flows, prior to this fix you would receive a 500 error due to the Flow object not being JSON serializable. 

This fixes the issue by serializing the Flow via json.dumps.

To test you will need to 
1) create a postmaster channel.
2) open postgres
3) retrieve the channels ID (NOT UUID) from the postgres channels_channel table ex:
`select id, uuid, type, address from channels_channel;`
4) retrieve the ID of any flow from the flows_flow table ex:
`select id, uuid from flows_flow;`
5) insert a new row into the flows_flow_channel_dependencies table to create a flow -> channel dependency:
`insert into flows_flow_channel_dependencies values (id, flow_id, channel_id)`

Now that you have successfully created a flow/channel depedency you may use curl to attempt to delete the channel by using the channels UUID:

`curl -H "Authorization: Token 0f9f28c265925b4bd99f20a228e393ef38e1149b" -X  GET "https://localhost/engage/ext/api/v2/channels.json?type=PSM&uuid=568a1f97-14dd-448e-b6fc-6dffbcd5e69f"`

You should receive. a result similar to this:
`{"name":null,"id":6,"uuid":"568a1f97-14dd-448e-b6fc-6dffbcd5e69f","is_active":true,"response":{"status":400,"errors":["Cannot delete Channel: cool [sms], used by 1 flows"],"dependent_flows":[{"name":"savecontactinfo","uuid":"0b4b8a65-3298-4f79-8592-6aeda5c0ca0d","spec_version":"13.1.0","language":"base","type":"messaging","nodes":[{"uuid":"062d0946-1d36-4ee6-95c3-08910a8ba785","actions":[{"attachments":[],"text":"hey dude whats your name?","type":"send_msg","quick_replies":[],"uuid":"8d770e09-5d35-43eb-9564-9932adad7b57"}],"exits":[{"uuid":"21fad95e-aa25-47bc-b8a9-7c1819585033","destination_uuid":"0af6cbef-f2e6-4164-8654-1c883bda95df"}]},{"uuid":"0af6cbef-f2e6-4164-8654-1c883bda95df","actions":[],"router":{"type":"switch","default_category_uuid":"5094775e-bcab-455f-8fd3-da37bc5a331e","cases":[],"categories":[{"uuid":"5094775e-bcab-455f-8fd3-da37bc5a331e","name":"All Responses","exit_uuid":"441b8031-e170-4b44-8176-18ed18e9d3c4"},{"uuid":"c3dc1a7b-1ee8-48b4-8d50-cfd729d7d8aa","name":"No Response","exit_uuid":"7030e47f-df0e-47fb-9c0e-ce87e46f35e4"}],"operand":"@input.text","wait":{"type":"msg","timeout":{"seconds":300,"category_uuid":"c3dc1a7b-1ee8-48b4-8d50-cfd729d7d8aa"}},"result_name":"Name"},"exits":[{"uuid":"441b8031-e170-4b44-8176-18ed18e9d3c4","destination_uuid":null},{"uuid":"7030e47f-df0e-47fb-9c0e-ce87e46f35e4"}]}],"_ui":{"nodes":{"062d0946-1d36-4ee6-95c3-08910a8ba785":{"position":{"left":0,"top":13},"type":"execute_actions"},"0af6cbef-f2e6-4164-8654-1c883bda95df":{"type":"wait_for_response","position":{"left":0,"top":100},"config":{"cases":{}}}}},"revision":9,"expire_after_minutes":10080,"metadata":{"revision":1},"localization":{}}]}}`


