### PR TITLE
P4-1658 - Add VK mode to postmaster channel

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -69,6 +69,7 @@ PM_WHATSAPP_SCHEME = "pm_whatsapp"
 PM_TELEGRAM_SCHEME = "pm_telegram"
 PM_SIGNAL_SCHEME = "pm_signal"
 PM_LINE_SCHEME = "pm_line"
+PM_VK_SCHEME = "pm_vk"
 
 # Scheme, Label, Export/Import Header, Context Key
 URN_SCHEME_CONFIG = (
@@ -90,6 +91,7 @@ URN_SCHEME_CONFIG = (
     (PM_TELEGRAM_SCHEME, _("Postmaster Telegram identifier"), PM_TELEGRAM_SCHEME),
     (PM_SIGNAL_SCHEME, _("Postmaster Signal identifier"), PM_SIGNAL_SCHEME),
     (PM_LINE_SCHEME, _("Postmaster Line identifier"), PM_LINE_SCHEME),
+    (PM_VK_SCHEME, _("Postmaster VK identifier"), PM_VK_SCHEME),
     (VK_SCHEME, _("VK identifier"), VK_SCHEME),
 )
 

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -19,7 +19,7 @@ from temba.contacts.models import (
     WHATSAPP_SCHEME,
     ContactField,
     ContactURN,
-    PM_WHATSAPP_SCHEME, PM_TELEGRAM_SCHEME, PM_SIGNAL_SCHEME, PM_LINE_SCHEME)
+    PM_WHATSAPP_SCHEME, PM_TELEGRAM_SCHEME, PM_SIGNAL_SCHEME, PM_LINE_SCHEME, PM_VK_SCHEME)
 from temba.ivr.models import IVRCall
 from temba.msgs.models import ERRORED, FAILED
 
@@ -42,6 +42,7 @@ URN_SCHEME_ICONS = {
     PM_TELEGRAM_SCHEME: "icon-telegram",
     PM_SIGNAL_SCHEME: "icon-signal",
     PM_LINE_SCHEME: "icon-line",
+    PM_VK_SCHEME: "icon-vk",
 }
 
 ACTIVITY_ICONS = {


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Added Postmaster VK channel and scheme

#### Release Note
Added Postmaster VK support to engage

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

Image: `istresearch/p4-engage:ci-4.0.3-P4-1658`

1. Spin up an entire 4.0.3-dev engage stack, using a mailroom with `pm_vk` added as a scheme to `MAILROOM_CUSTOM_SCHEMES`
2. Add/register a postmaster channel using VK Mode
3. Ensure that you can create a new contact using a `Postmaster VK ` identifier. 
4. Ensure that you can send messages to the contact using a `Update Contact`->`Channel` node  in a flow. 
5. Ensure that you can receive messages over the new channel. 