### PR TITLE
Bug Fix - Fixing Postmaster channel edit, make Name field readonly, C…

### DIFF
--- a/temba/channels/types/postmaster/type.py
+++ b/temba/channels/types/postmaster/type.py
@@ -4,20 +4,21 @@ from django.utils.translation import ugettext_lazy as _
 
 from temba.channels.types.postmaster.views import ClaimView
 
-from temba.utils.fields import SelectWidget
 from .. import TYPES
 
 from ...models import ChannelType, Channel
 from ...views import UpdateChannelForm
-from django import forms
+
 
 class UpdatePostmasterForm(UpdateChannelForm):
     CHAT_MODE_CHOICES = getattr(settings, "CHAT_MODE_CHOICES", ())
 
+    def __init__(self, *args, **kwargs):
+        super(UpdatePostmasterForm, self).__init__(*args, **kwargs)
+
     class Meta(UpdateChannelForm.Meta):
         fields = "name", "address", "schemes"
-        config_fields = ["schemes", ]
-        readonly = ("address", "name")
+        readonly = ("address", "schemes")
         helps = {"schemes": _("The Chat Mode that Postmaster will operate under.")}
         labels = {"schemes": _("Chat Mode")}
 
@@ -29,14 +30,15 @@ class UpdatePostmasterForm(UpdateChannelForm):
                 prefix = ''
             chat_mode_choices.append(('{}{}'.format(prefix, label).lower(), label))
         chat_mode_choices = tuple(chat_mode_choices)
-        widgets = {"schemes": SelectWidget(choices=chat_mode_choices, attrs={"style": "width:360px"})}
 
     def clean(self):
         self._validate_unique = True
         config = self.object.config
-        scheme = self.cleaned_data['schemes'][0]
+        scheme = None
+        if hasattr(self.cleaned_data, 'scheme'):
+            scheme = self.cleaned_data['schemes'][0]
         channel = self.object
-        if channel.org is not None:
+        if channel.org is not None and scheme is not None:
             channels = Channel.objects.filter(channel_type=ClaimView.code, is_active=True, address=config['device_id'])
             for ch in channels:
                 if ch.config.get('chat_mode') == scheme and ch.org.id == channel.org.id:
@@ -51,7 +53,9 @@ class UpdatePostmasterForm(UpdateChannelForm):
 
     def save(self, commit=True):
         config = self.object.config
-        config[Channel.CONFIG_CHAT_MODE] = self.cleaned_data['schemes'][0]
+
+        if hasattr(self.cleaned_data, 'schemes'):
+            config[Channel.CONFIG_CHAT_MODE] = self.cleaned_data['schemes'][0]
 
         import temba.contacts.models as Contacts
         prefix = 'PM_'
@@ -67,8 +71,6 @@ class UpdatePostmasterForm(UpdateChannelForm):
             pm_chat_mode = 'SMS'
             prefix = ''
 
-        self.object.name = '{} [{}]'.format(config['device_name'],
-                                            '{}{}'.format(prefix, dict(ClaimView.Form.CHAT_MODE_CHOICES)[pm_chat_mode]).lower())
         schemes = [getattr(Contacts,
                            '{}{}_SCHEME'.format(prefix, dict(ClaimView.Form.CHAT_MODE_CHOICES)[pm_chat_mode]).upper())]
         self.object.schemes = schemes


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
chat mode and address fields now read only for Channel edit page for PostMaster channels.

#### Release Note
chat mode and address fields now read only for Channel edit page for PostMaster channels.

#### Breaking Changes
N/A

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

- Setup a full Engage stack.
- Navigate to the Orgs home page or to the channels page and select a Postmaster channel.
- From the channel Read page, select Edit.

Expected Results:
The address and chat mode fields should be read only. The Name field should be editable.

