### PR TITLE
P4-1689 - Reverting Editors channel_claim revocation

### DIFF
--- a/temba/settings_common.py
+++ b/temba/settings_common.py
@@ -729,7 +729,7 @@ GROUP_PERMISSIONS = {
         "orgs.usersettings_update",
         "channels.channel_api",
         "channels.channel_bulk_sender_options",
-        # "channels.channel_claim",
+        "channels.channel_claim",
         "channels.channel_configuration",
         "channels.channel_create",
         "channels.channel_create_bulk_sender",


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

Engage - Send Message Button Requires Admin

## Summary
Reverting existing changes to settings_common.py Editor permissions due to a bug that requires Editors to have channel_claim roles to broadcast messages.

#### Release Note
Adding channel_claim role to Editors

#### Breaking Changes
N/A

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification
See https://istresearch.atlassian.net/browse/P4-1689 for bug details.

Be sure to run `manage.py makemigrations` &  `manage.py migrate --run-syncdb` to apply the DB changes.


