### PR TITLE
P4-1815, P4-1816 - Viber and Line modes for Postmaster

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -68,6 +68,7 @@ FACEBOOK_PATH_REF_PREFIX = "ref:"
 PM_WHATSAPP_SCHEME = "pm_whatsapp"
 PM_TELEGRAM_SCHEME = "pm_telegram"
 PM_SIGNAL_SCHEME = "pm_signal"
+PM_VIBER_SCHEME = "pm_viber"
 PM_LINE_SCHEME = "pm_line"
 PM_VK_SCHEME = "pm_vk"
 
@@ -90,6 +91,7 @@ URN_SCHEME_CONFIG = (
     (PM_WHATSAPP_SCHEME, _("Postmaster WhatsApp identifier"), PM_WHATSAPP_SCHEME),
     (PM_TELEGRAM_SCHEME, _("Postmaster Telegram identifier"), PM_TELEGRAM_SCHEME),
     (PM_SIGNAL_SCHEME, _("Postmaster Signal identifier"), PM_SIGNAL_SCHEME),
+    (PM_VIBER_SCHEME, _("Postmaster Viber identifier"), PM_VIBER_SCHEME),
     (PM_LINE_SCHEME, _("Postmaster Line identifier"), PM_LINE_SCHEME),
     (PM_VK_SCHEME, _("Postmaster VK identifier"), PM_VK_SCHEME),
     (VK_SCHEME, _("VK identifier"), VK_SCHEME),

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -19,7 +19,7 @@ from temba.contacts.models import (
     WHATSAPP_SCHEME,
     ContactField,
     ContactURN,
-    PM_WHATSAPP_SCHEME, PM_TELEGRAM_SCHEME, PM_SIGNAL_SCHEME, PM_LINE_SCHEME, PM_VK_SCHEME)
+    PM_WHATSAPP_SCHEME, PM_TELEGRAM_SCHEME, PM_SIGNAL_SCHEME, PM_LINE_SCHEME, PM_VK_SCHEME, PM_VIBER_SCHEME)
 from temba.ivr.models import IVRCall
 from temba.msgs.models import ERRORED, FAILED
 
@@ -43,6 +43,7 @@ URN_SCHEME_ICONS = {
     PM_SIGNAL_SCHEME: "icon-signal",
     PM_LINE_SCHEME: "icon-line",
     PM_VK_SCHEME: "icon-vk",
+    PM_VIBER_SCHEME: "icon-viber",
 }
 
 ACTIVITY_ICONS = {


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [x] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Added support for Viber and Line postmaster modes

#### Release Note
Line and Viber postmaster modes can now be registered.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Register a new postmaster line and viber channel. An example curl is below to manually register a channel using the add channel endpoint. Replace `chat_mode=VB` with `chat_mode=LN` to register a line channel.
```
curl --location --request POST 'http://localhost:8001/ist/ext/api/v2/channels.json?type=PSM&device_id=123&chat_mode=VB&device_name=tester&claim_code=YOUR_CLAIMCODE_HERE&org_id=1' \
--header 'Authorization: Token ENGAGE_SUPERADMIN_TOKEN'
```
2. Ensure you can add contact URNs with the `pm_line` and `pm_viber` schemes. 
