### PR TITLE
P4-1885 - Add twitter scheme for PM channels

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -71,6 +71,7 @@ PM_SIGNAL_SCHEME = "pm_signal"
 PM_VIBER_SCHEME = "pm_viber"
 PM_LINE_SCHEME = "pm_line"
 PM_VK_SCHEME = "pm_vk"
+PM_TWITTER_SCHEME = "pm_twitter"
 
 # Scheme, Label, Export/Import Header, Context Key
 URN_SCHEME_CONFIG = (
@@ -94,6 +95,7 @@ URN_SCHEME_CONFIG = (
     (PM_VIBER_SCHEME, _("Postmaster Viber identifier"), PM_VIBER_SCHEME),
     (PM_LINE_SCHEME, _("Postmaster Line identifier"), PM_LINE_SCHEME),
     (PM_VK_SCHEME, _("Postmaster VK identifier"), PM_VK_SCHEME),
+    (PM_TWITTER_SCHEME, _("Postmaster Twitter identifier"), PM_TWITTER_SCHEME),
     (VK_SCHEME, _("VK identifier"), VK_SCHEME),
 )
 

--- a/temba/contacts/templatetags/contacts.py
+++ b/temba/contacts/templatetags/contacts.py
@@ -19,7 +19,8 @@ from temba.contacts.models import (
     WHATSAPP_SCHEME,
     ContactField,
     ContactURN,
-    PM_WHATSAPP_SCHEME, PM_TELEGRAM_SCHEME, PM_SIGNAL_SCHEME, PM_LINE_SCHEME, PM_VK_SCHEME, PM_VIBER_SCHEME)
+    PM_WHATSAPP_SCHEME, PM_TELEGRAM_SCHEME, PM_SIGNAL_SCHEME, PM_LINE_SCHEME,
+    PM_VK_SCHEME, PM_VIBER_SCHEME, PM_TWITTER_SCHEME)
 from temba.ivr.models import IVRCall
 from temba.msgs.models import ERRORED, FAILED
 
@@ -44,6 +45,7 @@ URN_SCHEME_ICONS = {
     PM_LINE_SCHEME: "icon-line",
     PM_VK_SCHEME: "icon-vk",
     PM_VIBER_SCHEME: "icon-viber",
+    PM_TWITTER_SCHEME: "icon-twitter",
 }
 
 ACTIVITY_ICONS = {


### PR DESCRIPTION
# For the Reviewer
- [x] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Add twitter scheme to postmaster channel. 

#### Release Note
A new postmaster twitter URN scheme has been added

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [x] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Register a new postmaster twitter channel. An example curl is below to manually register a channel using the add channel endpoint. 
```
curl --location --request POST 'http://localhost:8001/ist/ext/api/v2/channels.json?type=PSM&device_id=123&chat_mode=TWTR&device_name=tester&claim_code=YOUR_CLAIMCODE_HERE&org_id=1' \
--header 'Authorization: Token ENGAGE_SUPERADMIN_TOKEN'
```
2. Ensure you can add contact URNs with the `pm_twitter`  scheme. 
