### PR TITLE
P4-1963 - Engage/Courier channel purge/kill switch

### DIFF
--- a/temba/channels/urls.py
+++ b/temba/channels/urls.py
@@ -3,7 +3,7 @@ from django.conf.urls import include, url
 from temba.utils.views import CourierURLHandler
 
 from .models import Channel
-from .views import ChannelCRUDL, ChannelEventCRUDL, ChannelLogCRUDL
+from .views import ChannelCRUDL, ChannelEventCRUDL, ChannelLogCRUDL, PurgeOutbox
 
 # we iterate all our channel types, finding all the URLs they want to wire in
 courier_urls = []
@@ -28,4 +28,5 @@ urlpatterns = [
     url(r"^channels/", include(ChannelCRUDL().as_urlpatterns() + ChannelLogCRUDL().as_urlpatterns())),
     url(r"^c/", include(courier_urls)),
     url(r"^channels/types/", include(type_urls)),
+    url(r"^channels/purge/(?P<channel_uuid>[^/]+)/$", PurgeOutbox.as_view(), name="channels.purge_outbox"),
 ]

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -11,6 +11,7 @@ import phonenumbers
 import pytz
 import requests
 import twilio.base.exceptions
+from django.views.generic.base import View
 from django_countries.data import COUNTRIES
 from smartmin.views import (
     SmartCRUDL,
@@ -1265,6 +1266,35 @@ class UpdateTelChannelForm(UpdateChannelForm):
     class Meta(UpdateChannelForm.Meta):
         helps = {"address": _("Phone number of this channel")}
 
+
+class PurgeOutbox(View):  # pragma: no cover
+
+    @csrf_exempt
+    def dispatch(self, *args, **kwargs):
+        return super().dispatch(*args, **kwargs)
+
+    def get(self, request, *args, **kwargs):
+        courier_url = getattr(settings, "COURIER_URL", ())
+        response = ""
+        if courier_url is not None and len(courier_url) > 0 \
+                and 'channel_uuid' in kwargs and kwargs['channel_uuid'] is not None:
+            full_courier_url = "{}/purge/{}".format(courier_url, kwargs['channel_uuid'])
+            r = None
+            try:
+                r = requests.post(full_courier_url, headers={"Content-Type": "{}".format("application/json")})
+                response = "The courier service returned with status {}: {}".format(r.status_code,
+                                                                                    json.loads(r.content)['message'])
+            except ConnectionError as e:
+                response = "An unknown error has occured."
+        else:
+            if courier_url is None or len(courier_url) == 0:
+                response = "An error has occurred. Please check your courier URL configuration"
+            elif 'channel_uuid' not in kwargs or kwargs['channel_uuid'] is None:
+                response = "A valid channel ID must be provided"
+        return HttpResponse(response)
+
+    def post(self, request, *args, **kwargs):
+        return HttpResponse("ILLEGAL METHOD")
 
 class ChannelCRUDL(SmartCRUDL):
     model = Channel

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -46,6 +46,8 @@
           - if caller and caller != sender
             <a class="btn btn-tiny" href="{% url 'channels.channellog_list' caller.uuid %}?sessions=1">{%trans "Call Log"%}</a>
 
+      <a class="purge-outbox btn btn-tiny" href="{% url 'channels.purge_outbox' channel.uuid%}">{%trans "Purge Outbox"%}</a>
+
       -for link in object.get_type.extra_links
         <a class="btn btn-tiny" href="{% url link.name object.uuid %}">{{ link.link }}</a>
 
@@ -377,6 +379,22 @@
 
           {% endif %}
 
+      .purge-outbox.hide
+        .title
+          -trans "Purge Outbox"
+        .body
+          %p
+            -trans "Purge all messages from the outbox?"
+          %p
+            -trans "Once the outbox is purged, it's messages will be gone forever. There is no way to undo this operation."
+
+      .purge-outbox-success.hide
+        .title
+          -trans "Purge Successful"
+      .purge-outbox-error.hide
+        .title
+          -trans "An error has occured"
+
     %a#deletion-form.posterize{href:'{% url "channels.channel_delete" object.pk %}'}
 
     .remove-sender.hide
@@ -504,6 +522,44 @@
   <script src="{{ STATIC_URL }}bower/highcharts/highcharts.js"></script>
 
 :javascript
+
+  {% if org_perms.channels.channel_delete %}
+    $(".purge-outbox").live('click', function(e){
+        e.preventDefault();
+        modal = new ConfirmationModal($('.purge-outbox > .title').html(), $('.purge-outbox > .body').html());
+        modal.addClass('alert');
+        modal.setListeners({onPrimary: function(){
+              $.ajax({
+                  type: "GET",
+                  url: "{% url 'channels.purge_outbox' channel.uuid%}",
+                  success: function(data, textStatus, xhr){
+                    var successModal = new ConfirmationModal($('.purge-outbox-success > .title').html(), data);
+                    successModal.addClass('alert');
+                    successModal.show();
+                    successModal.setListeners({onPrimary: function(){
+                      successModal.dismiss();
+                    }}, false);
+                    successModal.hideSecondaryButton();
+                    successModal.setPrimaryButton('{% trans "Ok" %}');
+                    modal.dismiss();
+                  },
+                  error: function(request, status, error){
+                    var errorModal = new ConfirmationModal($('.purge-outbox-error > .title').html(), request.status + " " + error);
+                    errorModal.addClass('alert');
+                    errorModal.setListeners({onPrimary: function(){
+                      errorModal.dismiss();
+                    }}, false);
+                    errorModal.hideSecondaryButton();
+                    errorModal.show();
+                    modal.dismiss();
+                  }
+                });
+            }}, false);
+        modal.setPrimaryButton('{% trans "Purge" %}');
+
+        modal.show();
+        });
+  {% endif %}
 
   {% if org_perms.channels.channel_delete %}
     $(".remove-channel").live('click', function(){


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
Engage P4-1963/ Courier P4-1934 GUI exposure of the kill-switch.

## Summary
New Button to expose the new Courier kill-switch functionality along with code to gracefully handle errors.

#### Release Note
Channel's now have a Purge Outbox kill-switch.

#### Breaking Changes
<Description for Techops of how to handle changes, migrations, updates>None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Standup Engage 4.0.x with the latest Courier dev from dockerhub since it supports this new purge (killswitch) endpoint.
2. (Optional) Queue up messages in your outbox.
3. Navigate to the channel that is designated to deliver the messages.
<img width="1205" alt="Screen Shot 2020-09-11 at 10 06 11 AM" src="https://user-images.githubusercontent.com/6886738/92992565-eff29100-f4b9-11ea-8441-413b2265ada3.png">
4. Click on the Purge Outbox button
5. Observe the results and compare to the Expected results.
6. Kill the courier service `docker-compose stop engage-courier`
7. Retry steps 2-5 and observe the expected error messages.

Expected:
4 - A confirmation dialog pops up when the Purge Outbox button is clicked.
<img width="686" alt="Screen Shot 2020-09-11 at 11 00 33 AM" src="https://user-images.githubusercontent.com/6886738/92992572-fb45bc80-f4b9-11ea-93b5-353210ff80f4.png">

5 - If the Purge button is clicked, Engage should submit a request to courier to purge the channel.
6 - The results should be displayed in another modal confirmation box.
<img width="692" alt="Screen Shot 2020-09-11 at 2 06 45 PM" src="https://user-images.githubusercontent.com/6886738/92992578-04cf2480-f4ba-11ea-8bce-bb8baed63be3.png">
7 - If the courier service is unreachable or returns a ConnectionException you should receive this message
<img width="648" alt="Screen Shot 2020-09-11 at 3 48 13 PM" src="https://user-images.githubusercontent.com/6886738/92992628-4fe93780-f4ba-11ea-91e9-678be97c7297.png">



