### PR TITLE
P4-2002 - Engage - Set default TPS values as a configurable value in …

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -83,7 +83,7 @@ class ChannelType(metaclass=ABCMeta):
     update_form = None
 
     max_length = -1
-    max_tps = None
+    max_tps = getattr(settings, "DEFAULT_TPS", 10)
     attachment_support = False
     free_sending = False
     quick_reply_text_size = 20
@@ -518,6 +518,7 @@ class Channel(TembaModel):
             address=address,
             config=config,
             role=role,
+            tps=getattr(settings, "DEFAULT", 10),
             schemes=schemes,
             created_by=user,
             modified_by=user,

--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1805,6 +1805,12 @@ class ChannelCRUDL(SmartCRUDL):
         def pre_save(self, obj):
             for field in self.form.config_fields:
                 obj.config[field] = self.form.cleaned_data[field]
+            if hasattr(obj, 'tps'):
+                max_tps = getattr(settings, "MAX_TPS", 50)
+                if obj.tps <= 0:
+                    obj.tps = getattr(settings, "DEFAULT_TPS", 10)
+                elif obj.tps > max_tps:
+                    obj.tps = max_tps
             return obj
 
         def post_save(self, obj):


### PR DESCRIPTION
…settings.py

# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
Companion PR: https://github.com/istresearch/rapidpro-docker/pull/80
Two new settings have been added (DEFAULT_TPS and MAX_TPS) with defaults of 10 and 50 respectively.

## Summary
The DEFAULT_TPS will be the default TPS value for all newly created channels since they are by default initialized  to null.
When saving or updating an existing channel, the TPS value may not exceed the values specified by MAX_TPS, and they may not be  lower than or equal to 0.
In the event of an attempt to update a Channel's TPS  value to <= 0 the TPS value will return to the value as defined in the DEFAULT_TPS setting.
#### Release Note
<Concise sentence describing change>Required.

#### Breaking Changes
<Description for Techops of how to handle changes, migrations, updates>None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

Create a channel and ensure that the TPS value is set to the DEFAULT_TPS setting.
Edit the channel and ensure that min and max boundaries are being properly handled.


