### PR TITLE
P4-2137 - Engage - links in the /channels/channel/ list pointing to i…

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1988,6 +1988,7 @@ class ChannelCRUDL(SmartCRUDL):
         title = _("Channels")
         fields = ("name", "address", "last_seen")
         search_fields = ("name", "address", "org__created_by__email")
+        link_url = 'uuid@channels.channel_read'
 
         def get_queryset(self, **kwargs):
             queryset = super().get_queryset(**kwargs)


### PR DESCRIPTION
…nvalid pages

# For the Reviewer
- [x] Code review complete
- [x] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

P4-2137 - Engage - links in the /channels/channel/ list pointing to invalid pages

## Summary
Fixed the links in the name column of the /channels/channel/ list page.

#### Release Note
Fixed the links in the name column of the /channels/channel/ list page.

#### Breaking Changes
N/A

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. As a non admin user navigate to /channels/channel/
2. click a channel from the name column
3. ensure that the proper channel/read page is loaded and you do should not receive a 404 error.