### PR TITLE
P4-1895 - Allow channel name updates via v2 api

### DIFF
--- a/temba/ext/api/v2/views.py
+++ b/temba/ext/api/v2/views.py
@@ -96,7 +96,8 @@ class ExtChannelWriteSerializer(WriteSerializer):
                 channel.name = '{} [{}]'.format(data.get("device_name"), schemes[0])
                 channel.config["device_name"] = data.get("device_name")
 
-                return channel.save(update_fields=["name", "config"])
+                save_resp = channel.save(update_fields=["name", "config"])
+                return channel
             else:
                 return channel
         else:


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

## Summary
Allow PSM channel name updates via V2 API

#### Release Note
- A PSM channel name can be updated If a UUID and device_name is provided to the v2 ext api.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Add a PSM channel to engage.
2. Submit a request to update the channel name:
```
curl --location --request POST 'http://localhost:8001/ist/ext/api/v2/channels.json?type=PSM&device_id={DEVICE_ID}&device_name={NEW_DEVICE_NAME}&uuid={CHANNEL_UUID}' --header 'Authorization: Token {API_TOKEN}'
```