### PR TITLE
P4-2321 - Engage - Manage Channels page filtering and sorting

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1652,6 +1652,7 @@ class ChannelCRUDL(SmartCRUDL):
         link_fields = ("name", "uuid", "address", "channel_log", "settings")
         field_config = {"channel_type": {"label": "Type"}, "uuid": {"label": "UUID"}}
         fields = ('name', 'channel_type', 'last_seen', 'uuid', 'address', 'country', 'device', 'channel_log', 'settings')
+        order_excluded_fields = ('channel_log', 'settings')
 
         def get_queryset(self, **kwargs):
             queryset = super().get_queryset(**kwargs)
@@ -1664,7 +1665,10 @@ class ChannelCRUDL(SmartCRUDL):
             sort = self.request.GET.get('sort')
             if sort:
                 if sort in set(self.fields):
-                    return queryset.filter(is_active=True).order_by("{}".format(sort)) \
+                    order = "-"
+                    if "order_asc" == self.request.GET.get("_order"):
+                        order = ""
+                    return queryset.filter(is_active=True).order_by("{}{}".format(order, sort)) \
                         .prefetch_related("sync_events")
             return queryset.filter(is_active=True).order_by("-role", "channel_type", "created_on") \
                 .prefetch_related("sync_events")
@@ -1696,6 +1700,18 @@ class ChannelCRUDL(SmartCRUDL):
             # return our queryset
             return queryset
 
+        def lookup_field_orderable(self, field):
+            """
+            Returns whether the passed in field is sortable or not, by default all 'raw' fields, that
+            is fields that are part of the model are sortable.
+            """
+            if field in self.order_excluded_fields:
+                return False
+
+            if field in self.fields:
+                return True
+            return False
+
         def pre_process(self, *args, **kwargs):
             # superuser sees things as they are
             if self.request.user.is_superuser:
@@ -1712,6 +1728,7 @@ class ChannelCRUDL(SmartCRUDL):
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)
             # delayed sync event
+            context['order'] = self.request.GET.get("sort")
             sync_events = SyncEvent.objects.filter(channel__in=context['channel_list']).order_by("-created_on")
             for channel in context['channel_list']:
                 if not (channel.created_on > timezone.now() - timedelta(hours=1)):

--- a/templates/channels/channel_manage.haml
+++ b/templates/channels/channel_manage.haml
@@ -65,7 +65,7 @@
                   - for field in fields
                     %th{ class:'header-{{field}} {% if view|field_orderable:field %}header {% if field == order %}{% if order_asc %}headerSortUp{% else %}headerSortDown{% endif %}{% endif %}{% endif %}', id:'header-{{field}}' }
                       -if field  != "channel_log" and field != "settings"
-                        <a href="{% url 'channels.channel_manage' %}?sort={{field}}{% if field == order and order_asc is null %}&_order=order_asc{% endif %}">{% get_label field %}</a>
+                        <a href="{% url 'channels.channel_manage' %}?sort={{field}}{% if search is not null %}&search={{search}}{% endif %}{% if field == order and order_asc is null %}&_order=order_asc{% endif %}">{% get_label field %}</a>
                       -else
                         {% get_label field %}
                 %tbody

--- a/templates/channels/channel_manage.haml
+++ b/templates/channels/channel_manage.haml
@@ -16,9 +16,11 @@
     -if org_perms.channels.channel_claim
       %div.channel-create-icon{title:"Add Channel", style:"float:right;"}
         -include "gear_links_include.haml"
+      %form
+        %input.input-medium.search-query{type:'text', placeholder:'Search', name:"search", value:"{{search}}"}
 
 -block top-form
-  - if view.search_fields and object_list
+  - if view.search_fields
     - block search-form
       %form
         %input.input-medium.search-query{type:'text', placeholder:'Search', name:"search", value:"{{search}}"}
@@ -43,8 +45,10 @@
                 %tr
                   - for field in fields
                     %th{ class:'header-{{field}} {% if view|field_orderable:field %}header {% if field == order %}{% if order_asc %}headerSortUp{% else %}headerSortDown{% endif %}{% endif %}{% endif %}', id:'header-{{field}}' }
-                      {% get_label field %}
-
+                      -if field  != "channel_log" and field != "settings"
+                        <a href="{% url 'channels.channel_manage' %}?sort={{field}}">{% get_label field %}</a>
+                      -else
+                        {% get_label field %}
                 %tbody
                   - for obj in object_list
                     %tr{ class:'{% cycle "row2" "row1" %} {% if not obj.is_active and obj|is_smartobject %}inactive{% endif %}'}

--- a/templates/channels/channel_manage.haml
+++ b/templates/channels/channel_manage.haml
@@ -1,6 +1,25 @@
 -extends "smartmin/base.html"
 -load smartmin i18n
 
+-block extra-style
+  :css
+    table .headerSortUp, table .headerSortDown {
+      background-color: rgba(141, 192, 219, 0.25);
+      text-shadow: 0 1px 1px rgba(255, 255, 255, 0.75);
+    }
+
+    table .headerSortDown {
+      background-image: url({{STATIC_URL}}img/sort_dsc.png);
+      background-repeat: no-repeat;
+      background-position: 98% 50%;
+    }
+
+    table .headerSortUp {
+      background-image: url({{STATIC_URL}}img/sort_asc.png);
+      background-repeat: no-repeat;
+      background-position: 98% 50%;
+    }
+
 -block page-top
   .row-fluid
     .span9
@@ -46,7 +65,7 @@
                   - for field in fields
                     %th{ class:'header-{{field}} {% if view|field_orderable:field %}header {% if field == order %}{% if order_asc %}headerSortUp{% else %}headerSortDown{% endif %}{% endif %}{% endif %}', id:'header-{{field}}' }
                       -if field  != "channel_log" and field != "settings"
-                        <a href="{% url 'channels.channel_manage' %}?sort={{field}}">{% get_label field %}</a>
+                        <a href="{% url 'channels.channel_manage' %}?sort={{field}}{% if field == order and order_asc is null %}&_order=order_asc{% endif %}">{% get_label field %}</a>
                       -else
                         {% get_label field %}
                 %tbody
@@ -99,7 +118,11 @@
       }
       {% endif %}
 
-      document.location = "{{url_params|urlencode}}_order=" + field;
+      if ($(this).find('a:first').length > 0) {
+        if ($(this).find('a:first')[0].href !=null) {
+          document.location = $(this).find('a:first')[0].href
+        }
+      }
     });
   });
 </script>


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
P4-2321 -  Manage Channels page filtering and sorting

## Summary
Within the UI, the "manage channels" page should be searchable based on (at least) the channel UUID and name. Additionally, the header rows should be sortable. 

#### Release Note
Added search filter and sorting for channel management page.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.
 
1. Standup the Rapidpro prereqs. (ex. https://github.com/istresearch/postoffice/blob/develop/README.md)
2. Navigate to {rootdir}/channels/channel/manage/
3.  Use the search bar and test the sort links by clicking the headers.
<img width="1665" alt="Screen Shot 2021-02-17 at 11 53 51 AM" src="https://user-images.githubusercontent.com/6886738/108365279-06b5b600-71c5-11eb-9844-f028644b4886.png">
4. Ensure that only valid sort options work(name, address,  uuid, channel_type,  country, device, last_seen): 
<img width="486" alt="Screen Shot 2021-02-17 at 11 54 05 AM" src="https://user-images.githubusercontent.com/6886738/108365402-2c42bf80-71c5-11eb-86a6-fc5bc0245b86.png">


