### PR TITLE
Feature/p4 2423 - Allow only deleting msg folders without active children labels

### DIFF
--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1402,7 +1402,7 @@ class Label(TembaModel):
 
         return changed
 
-    def has_active_children_labels(self):
+    def has_child_labels(self):
         return self.children.filter(is_active=True).exists()
 
     def is_folder(self):
@@ -1420,7 +1420,7 @@ class Label(TembaModel):
 
         # release our children if we are a folder
         if self.is_folder():
-            if self.has_active_children_labels():
+            if self.has_child_labels():
                 raise ValueError(f"Cannot delete Folder: {self.name}, since it is a parent to other labels")
 
         else:

--- a/temba/msgs/models.py
+++ b/temba/msgs/models.py
@@ -1402,6 +1402,9 @@ class Label(TembaModel):
 
         return changed
 
+    def has_active_children_labels(self):
+        return self.children.filter(is_active=True).exists()
+
     def is_folder(self):
         return self.label_type == Label.TYPE_FOLDER
 
@@ -1417,8 +1420,9 @@ class Label(TembaModel):
 
         # release our children if we are a folder
         if self.is_folder():
-            for label in self.children.all():
-                label.release(user)
+            if self.has_active_children_labels():
+                raise ValueError(f"Cannot delete Folder: {self.name}, since it is a parent to other labels")
+
         else:
             Msg.labels.through.objects.filter(label=self).delete()
 

--- a/temba/msgs/tests.py
+++ b/temba/msgs/tests.py
@@ -2574,7 +2574,12 @@ class LabelTest(TembaTest):
         label3.toggle_label([msg3], add=True)
 
         ExportMessagesTask.create(self.org, self.admin, label=label1)
+        with self.assertRaises(ValueError):
+            folder1.release(self.admin)
 
+        # can only release a folder once all its children are released
+        label1.release(self.admin)
+        label2.release(self.admin)
         folder1.release(self.admin)
         folder1.refresh_from_db()
 

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -831,7 +831,7 @@ class LabelForm(BaseLabelForm):
 
         super().__init__(*args, **kwargs)
 
-        self.fields["folder"].queryset = Label.folder_objects.filter(org=self.org)
+        self.fields["folder"].queryset = Label.folder_objects.filter(org=self.org, is_active=True)
 
 
 class FolderForm(BaseLabelForm):

--- a/templates/msgs/label_delete.haml
+++ b/templates/msgs/label_delete.haml
@@ -10,7 +10,7 @@
       .message
         {{error}}
 
-  -if object.has_active_children_labels
+  -if object.has_child_labels
     -blocktrans trimmed with name=object.name
       <b>{{name}}</b> cannot be deleted since it is a parent to other labels.
 

--- a/templates/msgs/label_delete.haml
+++ b/templates/msgs/label_delete.haml
@@ -1,0 +1,23 @@
+-extends 'includes/modal.html'
+-load i18n temba smartmin
+
+-block modal
+  -if error
+    .alert-text.mb-4
+      .title
+        -blocktrans trimmed with name=object.name
+          Uh oh, we couldn't delete {{name}}.
+      .message
+        {{error}}
+
+  -if object.has_active_children_labels
+    -blocktrans trimmed with name=object.name
+      <b>{{name}}</b> cannot be deleted since it is a parent to other labels.
+
+  -else
+    -blocktrans trimmed with name=object.name
+      Are you sure you want to delete <b>{{name}}</b>? This cannot be undone.
+
+    .hidden
+      %form(method="POST")
+        %input(type="submit" value="{{submit_button_name}}")

--- a/templates/msgs/msg_filter.haml
+++ b/templates/msgs/msg_filter.haml
@@ -26,7 +26,8 @@
       .body
         %p
           - if current_label.is_folder
-            - trans "Are you sure you want to remove this folder? This will also delete any labels contained in this folder."
+            - if not current_label.has_child_labels
+              - trans "Are you sure you want to remove this folder? This will also delete any labels contained in this folder."
           - else
             {% if current_label.dependent_flows.count == 0 %}
             - trans "Are you sure you want to remove this label?"
@@ -34,9 +35,14 @@
             - trans "This label cannot be removed because it in use."
             {% endif %}
         %p
-          %b {{ current_label }}
+          %b
+            - if not current_label.has_child_labels
+              {{ current_label }}
           %p
-            {% if current_label.dependent_flows.count == 0 %}
+            {% if current_label.has_child_labels %}
+              <b>{{ current_label }} </b>
+              - trans " cannot be deleted since it is a parent to other labels."
+            {% elif current_label.dependent_flows.count == 0 %}
               -trans "Once it is removed, it will be gone forever. There is no way to undo this operation."
             {% else %}
               {% blocktrans count num_flows=current_label.dependent_flows.count %}
@@ -64,7 +70,7 @@
       modal = new ConfirmationModal($('.deletion > .title').html(), $('.deletion > .body').html());
       modal.addClass('alert');
 
-      {% if current_label.dependent_flows.count == 0 %}
+      {% if current_label.dependent_flows.count == 0 and not current_label.has_child_labels%}
           modal.setListeners({onPrimary: function(){
             $('#delete-form').click();
           }}, false);


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
P4-2423 -  Allow only deleting msg folders without active children labels.

## Summary
Removed deleted folders from populating the create label dialog's parent folder selection menu.

#### Release Note
Removed deleted folders from populating the create label dialog's parent folder selection menu.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

**Part 1:**
1. Standup an engage stack.
2. Navigate to the messages page.
3. Create a folder,
4. Click create label,  then under the folder drop down select your newly created folder and click ok.
5. If the label creation was successful, navigate to the folder.
6. On the folder page, attempt to delete the folder.
7. You should receive a dialog informing you that you cannot delete the folder.

**Part 2:**
1. Delete the label and folder from the previous steps.
2. Now open the label creation dialog.
3. Select the folder drop down and verify that deleted folders are not populated in the dropdown.

