### PR TITLE
P4-2259 - Engage - Add ability for Rapidpro Archive model to use GovC…

### DIFF
--- a/temba/archives/models.py
+++ b/temba/archives/models.py
@@ -79,7 +79,8 @@ class Archive(models.Model):
     @classmethod
     def s3_client(cls):
         session = boto3.Session(
-            aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY
+            aws_access_key_id=settings.AWS_ACCESS_KEY_ID, aws_secret_access_key=settings.AWS_SECRET_ACCESS_KEY,
+            region_name=settings.AWS_S3_REGION_NAME
         )
         return session.client("s3")
 


### PR DESCRIPTION
…loud

# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
P4-2259 Add ability for Rapidpro Archive model to use GovCloud

## Summary
Add ability for Rapidpro Archive model to use GovCloud

#### Release Note
Add ability for Rapidpro Archive model to use GovCloud

#### Breaking Changes
N/A

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification
**(Optional) Test your govcloud S3 credentials using rp-archiver.**
1. Add the following service to your postoffice docker-compose.yml:
  ```archiver:
    image: praekeltfoundation/rp-archiver:6.0.1
    environment:
      - ARCHIVER_LOG_LEVEL=debug
      - ARCHIVER_DB=postgres://postgres:postgres@postgresql:5432/rapidpro?sslmode=disable
      - ARCHIVER_S3_REGION=us-gov-west-1
      - ARCHIVER_S3_BUCKET=some-dev-bucket
      - ARCHIVER_S3_ENDPOINT=s3.us-gov-west-1.amazonaws.com
      - ARCHIVER_AWS_ACCESS_KEY_ID=
      - ARCHIVER_AWS_SECRET_ACCESS_KEY=
      - ARCHIVER_RETENTION_PERIOD=1
  ```
2. running: `docker-compose up archiver` should result in the application running without error and without exiting.
3.  In Engage the following evironment variables are needed:
AWS_ACCESS_KEY_ID
AWS_SECRET_ACCESS_KEY
AWS_S3_REGION_NAME=us-gov-west-1 (or us-gov-east-1)
AWS_STORAGE_BUCKET_NAME

Note: None of the above variables are new, the archive code has been simply refactored to account for govcloud regions now thus AWS_S3_REGION_NAME must be set to the appropiate govcloud region.
ex. us-gov-west-1 (or us-gov-east-1).

4. Assuming you have successfully run the rp-archiver, you may now navigate a browser to your local engage instance's archive page: http://localhost:8001/engage/archive/message/ and you should be presented with a list of archives: <img width="1666" alt="Screen Shot 2021-03-23 at 3 51 51 PM" src="https://user-images.githubusercontent.com/6886738/112311477-233d8600-8c7c-11eb-821c-0004e423df21.png">
5. Right click and inspect and then select the network tab.
6. Now click on an archive link and ensure that The link does not return any errors or NON 200 status codes <img width="1676" alt="Screen Shot 2021-03-23 at 3 53 09 PM copy" src="https://user-images.githubusercontent.com/6886738/112311896-93e4a280-8c7c-11eb-991e-7fac7faaf0e8.png">
7. The link should be a fully formatted govcloud URL `(ex. https://tst-dev-engage.s3.us-gov-west-1.amazonaws.com/1/message_D20210322_82227a8bb78e08e7e2688d9f87db50e7.jsonl.gz?response-content-disposition=attachment%3B&response-content-type=application%2Foctet&response-content-encoding=none&AWSAccessKeyId=82hf9283g92g3g932&Signature=r7gyifi2i2gi2g7d723d3gid%3D&Expires=1616615572)` 
	(note: the accessID and signature have been replaced on the link above)
