### PR TITLE
P4-2488 - Postmaster Channel Add Redirect to show New Channel

### DIFF
--- a/templates/channels/types/postmaster/claim.haml
+++ b/templates/channels/types/postmaster/claim.haml
@@ -40,7 +40,7 @@
 
       $.get('{% url "ext.api.v2.channel.status" %}.json?claim_code={{po_qr.data.claim_code}}', function(data) {
         if (Array.isArray(data['results']) && data['results'].length > 0) {
-          window.location = '{% url "orgs.org_home" %}';
+          window.location = '{% url "channels.channel_manage" %}?search=' + data['results'][0]["address"];
         }
       });
     }, 5000);


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
See P4-2488 - Redirect to channels.channel_manage?search=device_id
Ex. Upon Postmaster channel creation the form will redirect to channels/channel/manage/?search=358240051111110

## Summary
Upon Postmaster channel creation the form will redirect to channels/channel/manage/?search=[address]

#### Release Note
Upon Postmaster channel creation the form will redirect to channels/channel/manage/?search=[address]

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. Standup Engage.
2. Create a postmasterr channel.
3. Ensure that you are redirected to the channel management page with a search param set to the new channels address:
Ex. channels/channel/manage/?search=358240051111110

