### PR TITLE
P4-1827 - Engage UI: Display Channel Config, Allow Admin Edit

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -11,6 +11,7 @@ import phonenumbers
 import pytz
 import requests
 import twilio.base.exceptions
+from django.contrib.postgres.forms import JSONField
 from django.views.generic.base import View
 from django_countries.data import COUNTRIES
 from smartmin.views import (
@@ -1238,6 +1239,7 @@ class BaseClaimNumberMixin(ClaimViewMixin):
 
 class UpdateChannelForm(forms.ModelForm):
     tps = forms.IntegerField(label="Maximum Transactions per Second", required=False)
+    config = JSONField()
 
     def __init__(self, *args, **kwargs):
         self.object = kwargs["object"]
@@ -1262,7 +1264,7 @@ class UpdateChannelForm(forms.ModelForm):
 
     class Meta:
         model = Channel
-        fields = "name", "address", "country", "alert_email", "tps"
+        fields = "name", "address", "country", "alert_email", "tps", "config"
         readonly = ("address", "country")
         labels = {"address": _("Address")}
         helps = {"address": _("The number or address of this channel")}


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
P4-1827 - Engage UI: Display Channel Config, Allow Admin Edit

## Summary
Exposes the config JSON field in the channel edit page.

#### Release Note
Exposed the config JSON field in the channel edit page.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Standup Engage.
2. Navigate to a channel to update.
3. Confirm that the config field exposed.

4. Test the config field by adding non JSON values and ensure that errors are presented.
<img width="650" alt="Screen Shot 2021-05-06 at 5 52 33 AM" src="https://user-images.githubusercontent.com/6886738/117300810-edc5b400-ae47-11eb-9103-cec3cbb40b4a.png">

5. Test the config by adding JSON values and ensure that the value is persisted.
<img width="625" alt="Screen Shot 2021-05-06 at 5 52 04 AM" src="https://user-images.githubusercontent.com/6886738/117301005-2bc2d800-ae48-11eb-87dc-4e6fe8fb17ed.png">

