### PR TITLE
P4-2737 - null Config prevents saving channel information

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1239,7 +1239,7 @@ class BaseClaimNumberMixin(ClaimViewMixin):
 
 class UpdateChannelForm(forms.ModelForm):
     tps = forms.IntegerField(label="Maximum Transactions per Second", required=False)
-    config = JSONField()
+    config = JSONField(required=False)
 
     def __init__(self, *args, **kwargs):
         self.object = kwargs["object"]
@@ -1248,13 +1248,6 @@ class UpdateChannelForm(forms.ModelForm):
         super().__init__(*args, **kwargs)
 
         self.config_fields = []
-
-        if TEL_SCHEME in self.object.schemes:
-            self.add_config_field(
-                Channel.CONFIG_ALLOW_INTERNATIONAL,
-                forms.BooleanField(required=False, help_text=_("Allow international sending")),
-                False,
-            )
 
     def add_config_field(self, config_key, field, default):
         field.initial = self.instance.config.get(config_key, default)


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

P4-2737 - Fixes Channel UpdateForm bug caused by null config fields.

## Summary
P4-2737 - Fixes Channel UpdateForm bug caused by null config fields.

#### Release Note
Fixed Channel UpdateForm bug caused by null config fields.

#### Breaking Changes
<Description for Techops of how to handle changes, migrations, updates>None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Do this: `$ run-this.sh`
2. Look for this.
3. Clean up with this command
