### PR TITLE
P4-2678 - Engage - Voice Call Retry Disable

### DIFF
--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -27,7 +27,7 @@ class IVRCall(ChannelConnection):
         (15, _("After 15 minutes")),
     )
 
-    IVR_RETRY_CHOICES = ((-1, _("Never")), (30, _("After 30 minutes")), (60, _("After 1 hour")), (1440, _("After 1 day")))
+    IVR_RETRY_CHOICES = ((1, _("Never")), (30, _("After 30 minutes")), (60, _("After 1 hour")), (1440, _("After 1 day")))
 
     objects = IVRManager()
 

--- a/temba/ivr/models.py
+++ b/temba/ivr/models.py
@@ -27,7 +27,7 @@ class IVRCall(ChannelConnection):
         (15, _("After 15 minutes")),
     )
 
-    IVR_RETRY_CHOICES = ((30, _("After 30 minutes")), (60, _("After 1 hour")), (1440, _("After 1 day")))
+    IVR_RETRY_CHOICES = ((-1, _("Never")), (30, _("After 30 minutes")), (60, _("After 1 hour")), (1440, _("After 1 day")))
 
     objects = IVRManager()
 


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee
Requires mailroom PR: https://github.com/istresearch/mailroom/pull/22
P4-2678 - Add option to disable IVR Flow retry

## Summary
 Add option to disable IVR Flow retry

#### Release Note
 Add option to disable IVR Flow retry

#### Breaking Changes
N/A

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification
<img width="579" alt="Screen Shot 2021-07-20 at 1 52 40 PM" src="https://user-images.githubusercontent.com/6886738/126372960-2f1d006b-3424-42e0-8ac4-e8b15269b0c5.png">

1. Edit a flow and set Retry call if unable to connect to Never
2. Run the flow and reject the call so that it will be marked as Failed.
3. Wait to ensure that no retries are attempted.

1. Edit the same flow and set Retry to 30 minutes (Sorry, but I dont think we should add a test option for 1 minute retries!)
2. Run the flow and reject the call. 
3. Wait 30 minutes to ensure that a retry is attempted.
