### PR TITLE
P4-2999 - Make Nexmo/Telegram country field editable

### DIFF
--- a/temba/channels/types/nexmo/views.py
+++ b/temba/channels/types/nexmo/views.py
@@ -189,4 +189,4 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
 
 class UpdateForm(UpdateTelChannelForm):
     class Meta(UpdateTelChannelForm.Meta):
-        readonly = ("country",)
+        readonly = ()

--- a/temba/channels/types/telegram/type.py
+++ b/temba/channels/types/telegram/type.py
@@ -18,7 +18,7 @@ class UpdateTelegramForm(UpdateChannelForm):
     class Meta(UpdateChannelForm.Meta):
         fields = "name", "address", "country", "alert_email", "tps"
         config_fields = ["forward_id",]
-        readonly = ("address","country")
+        readonly = ("address")
 
 class TelegramType(ChannelType):
     """


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
Made the Nexmo country field editable (telegram also)

#### Release Note
Nexmo and Telegram channel country fields can now be edited. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

