### PR TITLE
Revert the flow in use PR, put the warning back in place for now.

### DIFF
--- a/temba/channels/models.py
+++ b/temba/channels/models.py
@@ -965,10 +965,9 @@ class Channel(TembaModel):
         """
         Releases this channel making it inactive
         """
-        # 4.0.10: we no longer want to deny removal of a channel based on flows.
-        #dependent_flows_count = self.dependent_flows.count()
-        #if dependent_flows_count > 0:
-        #    raise ValueError(f"Cannot delete Channel: {self.get_name()}, used by {dependent_flows_count} flows")
+        dependent_flows_count = self.dependent_flows.count()
+        if dependent_flows_count > 0:
+            raise ValueError(f"Cannot delete Channel: {self.get_name()}, used by {dependent_flows_count} flows")
 
         channel_type = self.get_type()
 

--- a/templates/channels/channel_read.haml
+++ b/templates/channels/channel_read.haml
@@ -351,16 +351,33 @@
         -trans "Remove Channel"
       .body
         %p
+          {% if object.dependent_flows.count == 0 %}
           -trans "Are you sure you want to remove this channel from your workspace?"
+          .number.text-center
+            {{ object.get_channel_type_display }} {{ object.get_address_display|default:'' }}
+          {% else %}
+          - trans "This channel cannot be removed because it in use."
+          .number.text-center
+            {{ object.get_channel_type_display }} {{ object.get_address_display|default:'' }}
+          {% endif %}
 
         %p
-          -trans "Once it is removed, it will be gone forever. There is no way to undo this operation."
+          {% if object.dependent_flows.count == 0 %}
+            -trans "Once it is removed, it will be gone forever. There is no way to undo this operation."
+          {% else %}
+            {% blocktrans trimmed count num_flows=object.dependent_flows.count %}
+            Used by {{num_flows}} flow:
+            {% plural %}
+            Used by {{num_flows}} flows:
+            {% endblocktrans %}
 
           %ul
           - for flow in object.dependent_flows.all
             %li
               %a{href:"{% url 'flows.flow_editor' flow.uuid %}"}
                 {{ flow.name }}
+
+          {% endif %}
 
       .purge-outbox.hide
         .title
@@ -549,10 +566,18 @@
       modal = new ConfirmationModal($('.deletion > .title').html(), $('.deletion > .body').html());
       modal.addClass('alert');
 
-	  modal.setListeners({onPrimary: function(){
-		$('#deletion-form').click();
-	  }}, false);
-	  modal.setPrimaryButton('{{ _("Remove")|escapejs }}');
+      {% if object.dependent_flows.count == 0 %}
+          modal.setListeners({onPrimary: function(){
+            $('#deletion-form').click();
+          }}, false);
+          modal.setPrimaryButton('{{ _("Remove")|escapejs }}');
+
+      {% else %}
+          modal.setListeners({onPrimary: function(){
+            modal.dismiss();
+          }}, false);
+          modal.setPrimaryButton('{{ _("Ok")|escapejs }}');
+      {% endif %}
 
       modal.show();
       });


### PR DESCRIPTION
This reverts PR #167 

# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
Description of changes.

#### Release Note
<Concise sentence describing change>Required.

#### Breaking Changes
<Description for Techops of how to handle changes, migrations, updates>None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Do this: `$ run-this.sh`
2. Look for this.
3. Clean up with this command
