### PR TITLE
P4-3035 - Remove country as readonly from default channel config

### DIFF
--- a/temba/channels/views.py
+++ b/temba/channels/views.py
@@ -1258,7 +1258,7 @@ class UpdateChannelForm(forms.ModelForm):
     class Meta:
         model = Channel
         fields = "name", "address", "country", "alert_email", "tps", "config"
-        readonly = ("address", "country")
+        readonly = ("address",)
         labels = {"address": _("Address")}
         helps = {"address": _("The number or address of this channel")}
 


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

<Reminder PR Title should be JIRA_NUMBER and Useful Description>

## Summary
While working on 2999 I failed to remove country as a readonly field from the default channel  config.  This fixes that. 

#### Release Note
The country field will be editable on any channels that have it. 

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

1. `docker-compose up -d --build`
2. Edit the settings on a channel that uses the country field. 
3. The country field should be writeable. 
