### PR TITLE
P4-3464: Contact Custom Fields edit button 500 error

### DIFF
--- a/temba/contacts/views.py
+++ b/temba/contacts/views.py
@@ -53,7 +53,6 @@ from temba.utils.fields import (
     TembaMultipleChoiceField,
 )
 from temba.utils.models import IDSliceQuerySet, patch_queryset_count
-
 from temba.utils.views import BulkActionMixin, ComponentFormMixin, NonAtomicMixin
 
 from .models import (
@@ -1292,6 +1291,11 @@ class ContactCRUDL(SmartCRUDL):
         success_url = "uuid@contacts.contact_read"
         success_message = ""
         submit_button_name = _("Save Changes")
+
+        def get_form_kwargs(self):
+            kwargs = super().get_form_kwargs()
+            kwargs["user"] = self.request.user
+            return kwargs
 
         def get_context_data(self, **kwargs):
             context = super().get_context_data(**kwargs)


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Merge accidentally left out a required method from upstream.

#### Release Note
Fixed Contact edit Custom Fields menu button giving a 500 error.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

Go to Staging and click on any Contact from any org you please to see contact details page. In hamberger menu, select "Custom Fields" and the popup dialog shows 500 error.

Do the same on Dev and it shows a drop down instead of an error.  The drop down is empty because there are no defined custom fields, but the main thing is there's no error for when someone eventually does create a custom field.
