### PR TITLE
P4-3467: unhide vonage/twilio

### DIFF
--- a/docker/Dockerfile.pyapp
+++ b/docker/Dockerfile.pyapp
@@ -57,12 +57,17 @@ RUN rsync -a /opt/rp/ ./ && rm -R /opt/rp
 ARG UWSGI_PORT
 ARG UWSGI_NUM_WORKERS
 ARG UWSGI_TIMEOUT
+# see https://uwsgi-docs.readthedocs.io/en/latest/LogFormat.html
+# local app debug env option to suppress uwsgi access logs: - UWSGI_DISABLE_LOGGING=True
 ENV UWSGI_VIRTUALENV=/venv \
     UWSGI_WSGI_FILE=temba/wsgi.py \
     UWSGI_HTTP=:$UWSGI_PORT \
     UWSGI_MASTER=1 \
     UWSGI_WORKERS=$UWSGI_NUM_WORKERS \
-    UWSGI_HARAKIRI=$UWSGI_TIMEOUT
+    UWSGI_HARAKIRI=$UWSGI_TIMEOUT \
+    UWSGI_LOGFORMAT_STRFTIME=true \
+    UWSGI_LOG_DATE='%Y-%m-%dT%H:%M:%SZ' \
+    UWSGI_LOGFORMAT='{"timestamp": "%(ftime)", "ip": "%(addr)", "http_method": "%(method)", "url": "%(uri)", "status": %(status), "size": %(size), "referrer": "%(referer)", "ua": "%(uagent)"}'
 EXPOSE $UWSGI_PORT
 
 # Enable HTTP 1.1 Keep Alive options for uWSGI (http-auto-chunked needed when ConditionalGetMiddleware not installed)

--- a/docker/Dockerfile.pyapp
+++ b/docker/Dockerfile.pyapp
@@ -67,7 +67,7 @@ ENV UWSGI_VIRTUALENV=/venv \
     UWSGI_HARAKIRI=$UWSGI_TIMEOUT \
     UWSGI_LOGFORMAT_STRFTIME=true \
     UWSGI_LOG_DATE='%Y-%m-%dT%H:%M:%SZ' \
-    UWSGI_LOGFORMAT='{"timestamp": "%(ftime)", "ip": "%(addr)", "http_method": "%(method)", "url": "%(uri)", "status": %(status), "size": %(size), "referrer": "%(referer)", "ua": "%(uagent)"}'
+    UWSGI_LOGFORMAT='{"timestamp": "%(ftime)", "app": "webserver", "ip": "%(addr)", "http_method": "%(method)", "url": "%(uri)", "status": %(status), "size": %(size), "referrer": "%(referer)", "ua": "%(uagent)"}'
 EXPOSE $UWSGI_PORT
 
 # Enable HTTP 1.1 Keep Alive options for uWSGI (http-auto-chunked needed when ConditionalGetMiddleware not installed)

--- a/docker/customizations/any/temba/channels/types/android/type.py
+++ b/docker/customizations/any/temba/channels/types/android/type.py
@@ -1,0 +1,24 @@
+from temba.contacts.models import URN
+
+from ...models import ChannelType
+from .views import ClaimView, UpdateForm
+
+
+class AndroidType(ChannelType):
+    """
+    An Android relayer app channel type
+    """
+
+    code = "A"
+
+    name = "Android"
+    icon = "icon-channel-android"
+
+    claim_view = ClaimView
+    update_form = UpdateForm
+
+    schemes = [URN.TEL_SCHEME]
+    max_length = -1
+    attachment_support = False
+    free_sending = False
+    show_config_page = False

--- a/docker/customizations/any/temba/channels/types/android/type.py
+++ b/docker/customizations/any/temba/channels/types/android/type.py
@@ -11,6 +11,9 @@ class AndroidType(ChannelType):
 
     code = "A"
 
+    # existing channels won't crash the system, but cannot add new channels.
+    beta_only = True
+
     name = "Android"
     icon = "icon-channel-android"
 

--- a/docker/customizations/any/temba/channels/views.py
+++ b/docker/customizations/any/temba/channels/views.py
@@ -1225,7 +1225,9 @@ class ChannelCRUDL(EngageChannelCRUDMixin, SmartCRUDL):
 
                 if ch_type.is_recommended_to(user):
                     recommended_channels.append(ch_type)
-                elif region_ignore_visible and region_aware_visible and ch_type.category:
+                #elif region_ignore_visible and region_aware_visible and ch_type.category:
+                # recommended channels _duplicated_, not either/or listings
+                if region_ignore_visible and region_aware_visible and ch_type.category:
                     types_by_category[ch_type.category.name].append(ch_type)
 
             return recommended_channels, types_by_category, True
@@ -1244,6 +1246,9 @@ class ChannelCRUDL(EngageChannelCRUDMixin, SmartCRUDL):
             context["recommended_channels"] = recommended_channels
             context["channel_types"] = types_by_category
             context["only_regional_channels"] = only_regional_channels
+            # engage features a single channel
+            from temba.channels.types.postmaster.type import PostmasterType
+            context["featured_channel"] = Channel.get_type_from_code(PostmasterType.code)
             return context
 
     class ClaimAll(Claim):
@@ -1256,7 +1261,9 @@ class ChannelCRUDL(EngageChannelCRUDMixin, SmartCRUDL):
                 region_aware_visible, region_ignore_visible = ch_type.is_available_to(user)
                 if ch_type.is_recommended_to(user):
                     recommended_channels.append(ch_type)
-                elif region_ignore_visible and ch_type.category:
+                #elif region_ignore_visible and ch_type.category:
+                # recommended channels _duplicated_, not either/or listings
+                if region_ignore_visible and ch_type.category:
                     types_by_category[ch_type.category.name].append(ch_type)
 
             return recommended_channels, types_by_category, False

--- a/docker/customizations/any/temba/settings_engage.py
+++ b/docker/customizations/any/temba/settings_engage.py
@@ -284,8 +284,7 @@ LOGGING = {
     "root": {"level": "WARNING", "handlers": ["default"]},
     'formatters': {
         'json': {
-            '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-            'format': '%(created)f %(asctime)s %(levelname)s %(name)s %(message)s',
+            '()': 'engage.utils.logs.CustomJsonFormatter',
         },
     },
     'handlers': {

--- a/docker/customizations/any/templates/channels/channel_claim.haml
+++ b/docker/customizations/any/templates/channels/channel_claim.haml
@@ -14,7 +14,7 @@
     .bg-gray-200.-mx-128.px-128
 
       -if featured_channel
-        .title.mb-4.mt-8
+        .title.mb-4.pt-8
           -trans "Featured"
 
         .card.link(href="{% url 'channels.types.'|add:featured_channel.slug|add:'.claim' %}" onclick="goto(event, this)")
@@ -27,7 +27,7 @@
               {% include featured_channel.get_claim_blurb %}
 
       -if recommended_channels
-        .title.mb-4.mt-8
+        .title.mb-4.pt-8
           -trans "Recommended"
 
         -for ch_type in recommended_channels
@@ -40,7 +40,7 @@
               .mt-2
                 {% include ch_type.get_claim_blurb %}
 
-      .title.mb-4.mt-8
+      .title.mb-4.pt-8
         -trans "Social Network Channels"
 
       -for ch_type in channel_types.SOCIAL_MEDIA
@@ -53,7 +53,7 @@
             .mt-2
               {% include ch_type.get_claim_blurb %}
 
-      .title.mb-4.mt-8
+      .title.mb-4.pt-8
         -trans "SMS and Voice Channels"
 
       -for ch_type in channel_types.PHONE
@@ -67,7 +67,7 @@
               {% include ch_type.get_claim_blurb %}
 
 
-      .title.mt-8
+      .title.pt-8
         -trans "API Channels"
 
       -for ch_type in channel_types.API
@@ -82,13 +82,16 @@
 
       -if only_regional_channels
 
-        .title.mt-8
+        .title.pt-8
           -trans "All Channels"
 
         {% url 'channels.channel_claim_all' as claim_all_url %}
         -blocktrans trimmed
           The channels above are the available channels for your region, but you can also <a class="inline" href="{{claim_all_url}}">view all channels</a>.
 
+      .pt-8
+        &nbsp;
+          
 -block form-buttons
 
 -block extra-script

--- a/docker/customizations/any/templates/channels/channel_claim.haml
+++ b/docker/customizations/any/templates/channels/channel_claim.haml
@@ -11,12 +11,26 @@
 
   .channel-options.mt-8
 
-    .bg-gray-200.-mx-128.px-128.py-12.mt-16
-      .title.mb-4
-        -trans "Recommended"
+    .bg-gray-200.-mx-128.px-128
 
-      -for ch_type in channel_types.PHONE
-        -if ch_type.code == "PSM"
+      -if featured_channel
+        .title.mb-4.mt-8
+          -trans "Featured"
+
+        .card.link(href="{% url 'channels.types.'|add:featured_channel.slug|add:'.claim' %}" onclick="goto(event, this)")
+          .relative
+            .text-base.absolute.text-gray-100.bg-icon{class:"{{ featured_channel.icon }}"}
+          .flex.flex-col.mx-20.relative
+            .title
+              {{ featured_channel.name }}
+            .mt-2
+              {% include featured_channel.get_claim_blurb %}
+
+      -if recommended_channels
+        .title.mb-4.mt-8
+          -trans "Recommended"
+
+        -for ch_type in recommended_channels
           .card.link(href="{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}" onclick="goto(event, this)")
             .relative
               .text-base.absolute.text-gray-100.bg-icon{class:"{{ ch_type.icon }}"}
@@ -26,7 +40,7 @@
               .mt-2
                 {% include ch_type.get_claim_blurb %}
 
-      .title.mb-4
+      .title.mb-4.mt-8
         -trans "Social Network Channels"
 
       -for ch_type in channel_types.SOCIAL_MEDIA
@@ -43,15 +57,14 @@
         -trans "SMS and Voice Channels"
 
       -for ch_type in channel_types.PHONE
-        -if ch_type.code != "BWI"
-          .card.link(href="{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}" onclick="goto(event, this)")
-            .relative
-              .text-base.absolute.text-gray-100.bg-icon{class:"{{ ch_type.icon }}"}
-            .flex.flex-col.mx-20.relative
-              .title
-                {{ch_type.name}}
-              .mt-2
-                {% include ch_type.get_claim_blurb %}
+        .card.link(href="{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}" onclick="goto(event, this)")
+          .relative
+            .text-base.absolute.text-gray-100.bg-icon{class:"{{ ch_type.icon }}"}
+          .flex.flex-col.mx-20.relative
+            .title
+              {{ch_type.name}}
+            .mt-2
+              {% include ch_type.get_claim_blurb %}
 
 
       .title.mt-8

--- a/engage/utils/logs.py
+++ b/engage/utils/logs.py
@@ -1,4 +1,22 @@
+from datetime import datetime
+from pythonjsonlogger.jsonlogger import JsonFormatter
 
+class CustomJsonFormatter(JsonFormatter):
+    """
+    Specify our standard log fields.
+    @see https://github.com/madzak/python-json-logger
+    """
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        log_record['name'] = record.name
+        if not log_record.get('timestamp'):
+            # this doesn't use record.created, so it is slightly off
+            now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            log_record['timestamp'] = now
+        if log_record.get('level'):
+            log_record['level'] = log_record['level'].upper()
+        else:
+            log_record['level'] = record.levelname
 
 class OrgPermLogInfoMixin:
     """

--- a/engage/utils/logs.py
+++ b/engage/utils/logs.py
@@ -17,6 +17,7 @@ class CustomJsonFormatter(JsonFormatter):
             log_record['level'] = log_record['level'].upper()
         else:
             log_record['level'] = record.levelname
+        log_record['app'] = 'webapp'
 
 class OrgPermLogInfoMixin:
     """

--- a/temba/channels/types/bandwidth_international/type.py
+++ b/temba/channels/types/bandwidth_international/type.py
@@ -16,6 +16,9 @@ class BandwidthInternationalType(ChannelType):
     code = "BWI"
     category = ChannelType.Category.PHONE
 
+    # existing channels won't crash the system, but cannot add new channels.
+    beta_only = True
+
     courier_url = r"^bwi/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive|status)$"
 
     name = "Bandwidth International"

--- a/temba/channels/types/nexmo/is-now-vonage.txt
+++ b/temba/channels/types/nexmo/is-now-vonage.txt
@@ -1,0 +1,1 @@
+Nexmo was purchased by Vonage and that is now the type.


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Replacing Android Channel with Postmaster accidentally also hid some channels; unhide them.

#### Release Note
Missing channels restored to the Add Channels page.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

https://engage.dev.istresearch.com/channels/channel/claim/

Add Channels page displays all the channels it should, again.  New area at top: Featured, which is always the PM channel. Also, Recommended channels are displayed again in their appropriate sections down below rather than their original "moved" condition. Show All Channels link at bottom should also display correctly, too.
