### PR TITLE
P4-3500: add error log and 451 status if org suspended

### DIFF
--- a/docker/Dockerfile.pyapp
+++ b/docker/Dockerfile.pyapp
@@ -57,12 +57,17 @@ RUN rsync -a /opt/rp/ ./ && rm -R /opt/rp
 ARG UWSGI_PORT
 ARG UWSGI_NUM_WORKERS
 ARG UWSGI_TIMEOUT
+# see https://uwsgi-docs.readthedocs.io/en/latest/LogFormat.html
+# local app debug env option to suppress uwsgi access logs: - UWSGI_DISABLE_LOGGING=True
 ENV UWSGI_VIRTUALENV=/venv \
     UWSGI_WSGI_FILE=temba/wsgi.py \
     UWSGI_HTTP=:$UWSGI_PORT \
     UWSGI_MASTER=1 \
     UWSGI_WORKERS=$UWSGI_NUM_WORKERS \
-    UWSGI_HARAKIRI=$UWSGI_TIMEOUT
+    UWSGI_HARAKIRI=$UWSGI_TIMEOUT \
+    UWSGI_LOGFORMAT_STRFTIME=true \
+    UWSGI_LOG_DATE='%Y-%m-%dT%H:%M:%SZ' \
+    UWSGI_LOGFORMAT='{"timestamp": "%(ftime)", "ip": "%(addr)", "http_method": "%(method)", "url": "%(uri)", "status": %(status), "size": %(size), "referrer": "%(referer)", "ua": "%(uagent)"}'
 EXPOSE $UWSGI_PORT
 
 # Enable HTTP 1.1 Keep Alive options for uWSGI (http-auto-chunked needed when ConditionalGetMiddleware not installed)

--- a/docker/Dockerfile.pyapp
+++ b/docker/Dockerfile.pyapp
@@ -67,7 +67,7 @@ ENV UWSGI_VIRTUALENV=/venv \
     UWSGI_HARAKIRI=$UWSGI_TIMEOUT \
     UWSGI_LOGFORMAT_STRFTIME=true \
     UWSGI_LOG_DATE='%Y-%m-%dT%H:%M:%SZ' \
-    UWSGI_LOGFORMAT='{"timestamp": "%(ftime)", "ip": "%(addr)", "http_method": "%(method)", "url": "%(uri)", "status": %(status), "size": %(size), "referrer": "%(referer)", "ua": "%(uagent)"}'
+    UWSGI_LOGFORMAT='{"timestamp": "%(ftime)", "app": "webserver", "ip": "%(addr)", "http_method": "%(method)", "url": "%(uri)", "status": %(status), "size": %(size), "referrer": "%(referer)", "ua": "%(uagent)"}'
 EXPOSE $UWSGI_PORT
 
 # Enable HTTP 1.1 Keep Alive options for uWSGI (http-auto-chunked needed when ConditionalGetMiddleware not installed)

--- a/docker/customizations/any/temba/channels/types/android/type.py
+++ b/docker/customizations/any/temba/channels/types/android/type.py
@@ -1,0 +1,24 @@
+from temba.contacts.models import URN
+
+from ...models import ChannelType
+from .views import ClaimView, UpdateForm
+
+
+class AndroidType(ChannelType):
+    """
+    An Android relayer app channel type
+    """
+
+    code = "A"
+
+    name = "Android"
+    icon = "icon-channel-android"
+
+    claim_view = ClaimView
+    update_form = UpdateForm
+
+    schemes = [URN.TEL_SCHEME]
+    max_length = -1
+    attachment_support = False
+    free_sending = False
+    show_config_page = False

--- a/docker/customizations/any/temba/channels/types/android/type.py
+++ b/docker/customizations/any/temba/channels/types/android/type.py
@@ -11,6 +11,9 @@ class AndroidType(ChannelType):
 
     code = "A"
 
+    # existing channels won't crash the system, but cannot add new channels.
+    beta_only = True
+
     name = "Android"
     icon = "icon-channel-android"
 

--- a/docker/customizations/any/temba/channels/views.py
+++ b/docker/customizations/any/temba/channels/views.py
@@ -1225,7 +1225,9 @@ class ChannelCRUDL(EngageChannelCRUDMixin, SmartCRUDL):
 
                 if ch_type.is_recommended_to(user):
                     recommended_channels.append(ch_type)
-                elif region_ignore_visible and region_aware_visible and ch_type.category:
+                #elif region_ignore_visible and region_aware_visible and ch_type.category:
+                # recommended channels _duplicated_, not either/or listings
+                if region_ignore_visible and region_aware_visible and ch_type.category:
                     types_by_category[ch_type.category.name].append(ch_type)
 
             return recommended_channels, types_by_category, True
@@ -1244,6 +1246,9 @@ class ChannelCRUDL(EngageChannelCRUDMixin, SmartCRUDL):
             context["recommended_channels"] = recommended_channels
             context["channel_types"] = types_by_category
             context["only_regional_channels"] = only_regional_channels
+            # engage features a single channel
+            from temba.channels.types.postmaster.type import PostmasterType
+            context["featured_channel"] = Channel.get_type_from_code(PostmasterType.code)
             return context
 
     class ClaimAll(Claim):
@@ -1256,7 +1261,9 @@ class ChannelCRUDL(EngageChannelCRUDMixin, SmartCRUDL):
                 region_aware_visible, region_ignore_visible = ch_type.is_available_to(user)
                 if ch_type.is_recommended_to(user):
                     recommended_channels.append(ch_type)
-                elif region_ignore_visible and ch_type.category:
+                #elif region_ignore_visible and ch_type.category:
+                # recommended channels _duplicated_, not either/or listings
+                if region_ignore_visible and ch_type.category:
                     types_by_category[ch_type.category.name].append(ch_type)
 
             return recommended_channels, types_by_category, False

--- a/docker/customizations/any/temba/settings_engage.py
+++ b/docker/customizations/any/temba/settings_engage.py
@@ -284,8 +284,7 @@ LOGGING = {
     "root": {"level": "WARNING", "handlers": ["default"]},
     'formatters': {
         'json': {
-            '()': 'pythonjsonlogger.jsonlogger.JsonFormatter',
-            'format': '%(created)f %(asctime)s %(levelname)s %(name)s %(message)s',
+            '()': 'engage.utils.logs.CustomJsonFormatter',
         },
     },
     'handlers': {

--- a/docker/customizations/any/temba/urls.py
+++ b/docker/customizations/any/temba/urls.py
@@ -92,7 +92,6 @@ def track_user(self):  # pragma: no cover
 User.track_user = track_user
 AnonymousUser.track_user = track_user
 
-
 def handler500(request):
     """
     500 error handler which includes ``request`` in the context.
@@ -106,3 +105,7 @@ def handler500(request):
     t = loader.get_template("500.html")
     return HttpResponseServerError(t.render({"request": request}))  # pragma: needs cover
 
+# overwrite a single method of a single class rather then stomp on the whole file
+from temba.api.v2.serializers import WriteSerializer as TembaWriteSerializer
+from engage.api.serializers import WriteSerializer as EngageWriteSerializer
+setattr(TembaWriteSerializer, 'run_validation', EngageWriteSerializer.run_validation)

--- a/docker/customizations/any/templates/channels/channel_claim.haml
+++ b/docker/customizations/any/templates/channels/channel_claim.haml
@@ -14,7 +14,7 @@
     .bg-gray-200.-mx-128.px-128
 
       -if featured_channel
-        .title.mb-4.mt-8
+        .title.mb-4.pt-8
           -trans "Featured"
 
         .card.link(href="{% url 'channels.types.'|add:featured_channel.slug|add:'.claim' %}" onclick="goto(event, this)")
@@ -27,7 +27,7 @@
               {% include featured_channel.get_claim_blurb %}
 
       -if recommended_channels
-        .title.mb-4.mt-8
+        .title.mb-4.pt-8
           -trans "Recommended"
 
         -for ch_type in recommended_channels
@@ -40,7 +40,7 @@
               .mt-2
                 {% include ch_type.get_claim_blurb %}
 
-      .title.mb-4.mt-8
+      .title.mb-4.pt-8
         -trans "Social Network Channels"
 
       -for ch_type in channel_types.SOCIAL_MEDIA
@@ -53,7 +53,7 @@
             .mt-2
               {% include ch_type.get_claim_blurb %}
 
-      .title.mb-4.mt-8
+      .title.mb-4.pt-8
         -trans "SMS and Voice Channels"
 
       -for ch_type in channel_types.PHONE
@@ -67,7 +67,7 @@
               {% include ch_type.get_claim_blurb %}
 
 
-      .title.mt-8
+      .title.pt-8
         -trans "API Channels"
 
       -for ch_type in channel_types.API
@@ -82,13 +82,16 @@
 
       -if only_regional_channels
 
-        .title.mt-8
+        .title.pt-8
           -trans "All Channels"
 
         {% url 'channels.channel_claim_all' as claim_all_url %}
         -blocktrans trimmed
           The channels above are the available channels for your region, but you can also <a class="inline" href="{{claim_all_url}}">view all channels</a>.
 
+      .pt-8
+        &nbsp;
+          
 -block form-buttons
 
 -block extra-script

--- a/docker/customizations/any/templates/channels/channel_claim.haml
+++ b/docker/customizations/any/templates/channels/channel_claim.haml
@@ -11,12 +11,26 @@
 
   .channel-options.mt-8
 
-    .bg-gray-200.-mx-128.px-128.py-12.mt-16
-      .title.mb-4
-        -trans "Recommended"
+    .bg-gray-200.-mx-128.px-128
 
-      -for ch_type in channel_types.PHONE
-        -if ch_type.code == "PSM"
+      -if featured_channel
+        .title.mb-4.mt-8
+          -trans "Featured"
+
+        .card.link(href="{% url 'channels.types.'|add:featured_channel.slug|add:'.claim' %}" onclick="goto(event, this)")
+          .relative
+            .text-base.absolute.text-gray-100.bg-icon{class:"{{ featured_channel.icon }}"}
+          .flex.flex-col.mx-20.relative
+            .title
+              {{ featured_channel.name }}
+            .mt-2
+              {% include featured_channel.get_claim_blurb %}
+
+      -if recommended_channels
+        .title.mb-4.mt-8
+          -trans "Recommended"
+
+        -for ch_type in recommended_channels
           .card.link(href="{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}" onclick="goto(event, this)")
             .relative
               .text-base.absolute.text-gray-100.bg-icon{class:"{{ ch_type.icon }}"}
@@ -26,7 +40,7 @@
               .mt-2
                 {% include ch_type.get_claim_blurb %}
 
-      .title.mb-4
+      .title.mb-4.mt-8
         -trans "Social Network Channels"
 
       -for ch_type in channel_types.SOCIAL_MEDIA
@@ -43,15 +57,14 @@
         -trans "SMS and Voice Channels"
 
       -for ch_type in channel_types.PHONE
-        -if ch_type.code != "BWI"
-          .card.link(href="{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}" onclick="goto(event, this)")
-            .relative
-              .text-base.absolute.text-gray-100.bg-icon{class:"{{ ch_type.icon }}"}
-            .flex.flex-col.mx-20.relative
-              .title
-                {{ch_type.name}}
-              .mt-2
-                {% include ch_type.get_claim_blurb %}
+        .card.link(href="{% url 'channels.types.'|add:ch_type.slug|add:'.claim' %}" onclick="goto(event, this)")
+          .relative
+            .text-base.absolute.text-gray-100.bg-icon{class:"{{ ch_type.icon }}"}
+          .flex.flex-col.mx-20.relative
+            .title
+              {{ch_type.name}}
+            .mt-2
+              {% include ch_type.get_claim_blurb %}
 
 
       .title.mt-8

--- a/engage/api/__init__.py
+++ b/engage/api/__init__.py
@@ -1,0 +1,22 @@
+from django.apps import AppConfig as BaseAppConfig
+
+default_app_config = 'engage.api.AppConfig'
+
+class AppConfig(BaseAppConfig):
+    """
+    django app labels must be unique; so override AppConfig to ensure uniqueness
+    """
+    name = "engage.api"
+    label = "engage_api"
+    verbose_name = "Engage API"
+
+
+# append a static method to the generic APIException class so we can start
+#   using a more standardized API response especially when an error occurs.
+from rest_framework.exceptions import APIException
+def _ExceptionResponseWithCause(cls, cause='Unknown', msg='Derp'):
+    return cls(detail={"error": {
+        'cause': cause,
+        'message': msg,
+    }})
+setattr(APIException, 'withCause', classmethod(_ExceptionResponseWithCause))

--- a/engage/api/exceptions.py
+++ b/engage/api/exceptions.py
@@ -1,0 +1,16 @@
+from rest_framework import status
+from rest_framework.exceptions import APIException
+
+from engage.api import _ExceptionResponseWithCause
+
+
+class BrokenLeg(APIException):
+    withCause=classmethod(_ExceptionResponseWithCause)
+
+class ValueException(ValueError):
+    withCause=classmethod(_ExceptionResponseWithCause)
+
+class FinancialException(BrokenLeg):
+    status_code = status.HTTP_451_UNAVAILABLE_FOR_LEGAL_REASONS
+    default_detail = {'error': {'cause': 'unavailable', 'message': 'Unavailable, for reasons.'}}
+    default_code = 'unavailable'

--- a/engage/api/serializers.py
+++ b/engage/api/serializers.py
@@ -1,0 +1,37 @@
+import logging
+from rest_framework import serializers
+from rest_framework.exceptions import ParseError
+
+from .exceptions import FinancialException
+
+class WriteSerializer(serializers.Serializer):
+    """
+    The normal REST framework way is to have the view decide if it's an update on existing instance or a create for a
+    new instance. Since logic for that gets relatively complex, have the serializer make that call.
+    """
+
+    def run_validation(self, data=serializers.empty):
+        logger = logging.getLogger(__name__)
+        if not isinstance(data, dict):
+            raise ParseError.withCause(
+                cause='JSON Parse Failure',
+                msg='Request body should be a single JSON object',
+            )
+
+        theOrg = self.context["org"]
+        if theOrg.is_flagged or theOrg.is_suspended:
+            state = "flagged" if theOrg.is_flagged else "suspended"
+            logger.error(f"API called using a token from a {state} workspace", extra={
+                'org': theOrg,
+                'org_id': theOrg.id,
+                'org_uuid': theOrg.uuid,
+                'flagged': theOrg.is_flagged,
+                'suspended': theOrg.is_suspended,
+                'api_call': self.context['request'],
+            })
+            raise FinancialException.withCause(
+                cause=f"workspace {state}",
+                msg=f"Sorry, your workspace is currently {state}. Please contact support.",
+            )
+
+        return super().run_validation(data)

--- a/engage/utils/__init__.py
+++ b/engage/utils/__init__.py
@@ -10,6 +10,7 @@ class AppConfig(BaseAppConfig):
     label = "engage_utils"
     verbose_name = "Engage Utilities"
 
+from engage.api.exceptions import ValueException
 
 def get_required_arg(arg_name, kwargs, bCheckForEmpty=True):
     """
@@ -24,4 +25,4 @@ def get_required_arg(arg_name, kwargs, bCheckForEmpty=True):
     if arg_name in kwargs and kwargs[arg_name] is not None:
         if not bCheckForEmpty or len(kwargs[arg_name]) > 0:
             return kwargs[arg_name]
-    raise ValueError(f"[{arg_name}] not defined.")
+    raise ValueException.withCause(cause='missing argument', msg=f"[{arg_name}] not defined.")

--- a/engage/utils/logs.py
+++ b/engage/utils/logs.py
@@ -1,4 +1,22 @@
+from datetime import datetime
+from pythonjsonlogger.jsonlogger import JsonFormatter
 
+class CustomJsonFormatter(JsonFormatter):
+    """
+    Specify our standard log fields.
+    @see https://github.com/madzak/python-json-logger
+    """
+    def add_fields(self, log_record, record, message_dict):
+        super(CustomJsonFormatter, self).add_fields(log_record, record, message_dict)
+        log_record['name'] = record.name
+        if not log_record.get('timestamp'):
+            # this doesn't use record.created, so it is slightly off
+            now = datetime.utcnow().strftime('%Y-%m-%dT%H:%M:%S.%fZ')
+            log_record['timestamp'] = now
+        if log_record.get('level'):
+            log_record['level'] = log_record['level'].upper()
+        else:
+            log_record['level'] = record.levelname
 
 class OrgPermLogInfoMixin:
     """

--- a/engage/utils/logs.py
+++ b/engage/utils/logs.py
@@ -17,6 +17,7 @@ class CustomJsonFormatter(JsonFormatter):
             log_record['level'] = log_record['level'].upper()
         else:
             log_record['level'] = record.levelname
+        log_record['app'] = 'webapp'
 
 class OrgPermLogInfoMixin:
     """

--- a/temba/channels/types/bandwidth_international/type.py
+++ b/temba/channels/types/bandwidth_international/type.py
@@ -16,6 +16,9 @@ class BandwidthInternationalType(ChannelType):
     code = "BWI"
     category = ChannelType.Category.PHONE
 
+    # existing channels won't crash the system, but cannot add new channels.
+    beta_only = True
+
     courier_url = r"^bwi/(?P<uuid>[a-z0-9\-]+)/(?P<action>receive|status)$"
 
     name = "Bandwidth International"

--- a/temba/channels/types/nexmo/is-now-vonage.txt
+++ b/temba/channels/types/nexmo/is-now-vonage.txt
@@ -1,0 +1,1 @@
+Nexmo was purchased by Vonage and that is now the type.

--- a/temba/ext/api/v2/views.py
+++ b/temba/ext/api/v2/views.py
@@ -1,5 +1,5 @@
+import logging
 import pytz
-from django.http import Http404
 from rest_framework import serializers, status
 from rest_framework.reverse import reverse
 
@@ -8,14 +8,15 @@ from temba.api.v2.views_base import (
     BaseAPIView,
     CreatedOnCursorPagination,
     ListAPIMixin,
-    DeleteAPIMixin, WriteAPIMixin)
+    DeleteAPIMixin,
+    WriteAPIMixin,
+)
 from rest_framework.response import Response
 from temba.channels.models import Channel
 from temba.ext.api.models import ExtAPIPermission
 from temba.api.models import SSLPermission, APIPermission
 from temba.api.v2.serializers import (ReadSerializer, WriteSerializer)
 from temba.orgs.models import Org
-import json
 
 class ExtChannelReadSerializer(ReadSerializer):
     country = serializers.SerializerMethodField()


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Return 451 status on API calls with tokens from orgs that are out of credits.

#### Release Note
Return the readily identifiable https status code 451 for when orgs need attention.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

Using a key from an org that is out of credits, call an API routine.
See the http status code return as 451 rather than 400.

e.g. Using Postman:
http://localhost/ext/api/v2/channels.json?type=PSM
header: Authorization: Token fe7ac1....
body data: {
    "claim_code": "DEPRECATED",
    "device_name": "fisch010",
    "device_id": "bla123",
    "chat_mode": "SMS",
    "org_id": 3,
    "org_num": 3
}
result:  451 Unavailable For Legal Reasons
{
    "error": {
        "cause": "workspace suspended",
        "message": "Sorry, your workspace is currently suspended. Please contact support."
    }
}

OR via PostOffice:
http://localhost/postoffice/relayer/register
{   
    "claim_code": "V78Z",
    "device_name": "fisch0104",
    "model": "bla1234",
    "modes": ["SMS", "TWTR"],
    "expect_api_key": true
![Screen Shot 2022-03-11 at 15 54 47](https://user-images.githubusercontent.com/1625533/157963691-9d666f6d-892c-41ea-a06a-aae3f9584080.png)

}
