### PR TITLE
P4-3568: various visual tweaks

### DIFF
--- a/docker/customizations/any/static/less/engage.less
+++ b/docker/customizations/any/static/less/engage.less
@@ -219,17 +219,38 @@ h5.contact-signup {
  This makes it harder to override/target CSS. haml was updated to include
  IDs for specific elements and we target the "slotted" div element for css.
  */
-temba-modax#send-via-pm_element > div {
+temba-modax > div.send-via-btn {
   cursor: pointer;
   height: 16px;
   width: 16px;
+  position: relative;
+  display: inline-block;
+  .tooltiptext {
+    visibility: hidden;
+    width: 200px;
+    background-color: var(--orgname-bkgd);
+    color: var(--color-nav-unselected);
+    font-family: "Roboto", 'Helvetica Neue', sans-serif;
+    font-weight: 200;
+    font-size: smaller;
+    -webkit-font-smoothing: auto;
+    -moz-osx-font-smoothing: auto;
+    text-align: center;
+    padding: 5px;
+    z-index: 5;
+    position: absolute;
+    bottom: 100%;
+    left: 50%;
+  }
+  &:hover .tooltiptext {
+    visibility: visible;
+  }
+}
+temba-modax#send-via-pm_element > div.send-via-btn {
   background: url("/sitestatic/engage/img/element-chat.svg");
   background-size: 16px;
 }
-temba-modax#send-via-pm_signal > div {
-  cursor: pointer;
-  height: 16px;
-  width: 16px;
+temba-modax#send-via-pm_signal > div.send-via-btn {
   background: url("/sitestatic/engage/img/signal-chat.svg");
   background-size: 16px;
 }

--- a/docker/customizations/any/static/less/engage.less
+++ b/docker/customizations/any/static/less/engage.less
@@ -212,6 +212,7 @@ h5.contact-signup {
   font-variant-caps: petite-caps;
   line-height: 1.875rem;
   height: 1.875rem;
+  border-radius: 5px;
 }
 /* ----------------------------------------------------
  temba components make use of https://lit.dev/ and use the "shadow-DOM".
@@ -270,6 +271,16 @@ temba-modax#send-via-pm_signal > div {
       content: "🏠";
       font-size: large;
     }
+  }
+
+  #org-name {
+    background-color: var(--orgname-bkgd);
+    min-width: 15em;
+    border: 1px solid #aaa;
+    border-radius: 4px;
+    color: var(--color-nav-unselected);
+    line-height: 28px;
+    text-align: center;
   }
 
   #org-picker-widget {

--- a/docker/customizations/any/temba/msgs/views.py
+++ b/docker/customizations/any/temba/msgs/views.py
@@ -1,0 +1,934 @@
+from datetime import date, timedelta
+
+from smartmin.views import (
+    SmartCreateView,
+    SmartCRUDL,
+    SmartDeleteView,
+    SmartFormView,
+    SmartListView,
+    SmartReadView,
+    SmartUpdateView,
+)
+
+from django import forms
+from django.conf import settings
+from django.contrib import messages
+from django.core.exceptions import ValidationError
+from django.forms import Form
+from django.http import HttpResponse, HttpResponseBadRequest, HttpResponseRedirect
+from django.urls import reverse
+from django.utils import timezone
+from django.utils.http import is_safe_url, urlquote_plus
+from django.utils.translation import ugettext_lazy as _
+
+from temba.archives.models import Archive
+from temba.channels.models import Channel
+from temba.contacts.models import ContactGroup
+from temba.contacts.search.omnibox import omnibox_deserialize, omnibox_query, omnibox_results_to_dict
+from temba.formax import FormaxMixin
+from temba.orgs.views import DependencyDeleteModal, ModalMixin, OrgObjPermsMixin, OrgPermsMixin
+from temba.utils import analytics, json, on_transaction_commit
+from temba.utils.fields import (
+    CheckboxWidget,
+    CompletionTextarea,
+    InputWidget,
+    JSONField,
+    OmniboxChoice,
+    SelectMultipleWidget,
+    SelectWidget,
+    TembaChoiceField,
+)
+from temba.utils.models import patch_queryset_count
+from temba.utils.views import BulkActionMixin, ComponentFormMixin
+
+from .models import INITIALIZING, QUEUED, Broadcast, ExportMessagesTask, Label, Msg, Schedule, SystemLabel
+from .tasks import export_messages_task
+
+
+class SendMessageForm(Form):
+
+    omnibox = JSONField(
+        label=_("Recipients"),
+        required=False,
+        help_text=_("The contacts to send the message to"),
+        widget=OmniboxChoice(
+            attrs={
+                "placeholder": _("Recipients, enter contacts or groups"),
+                "widget_only": True,
+                "groups": True,
+                "contacts": True,
+                "urns": True,
+            }
+        ),
+    )
+
+    text = forms.CharField(
+        widget=CompletionTextarea(
+            attrs={"placeholder": _("Hi @contact.name!"), "widget_only": True, "counter": "temba-charcount"}
+        )
+    )
+
+    schedule = forms.BooleanField(
+        widget=CheckboxWidget(attrs={"widget_only": True}),
+        required=False,
+        label=_("Schedule for later"),
+        help_text=None,
+    )
+    step_node = forms.CharField(widget=forms.HiddenInput, max_length=36, required=False)
+
+    def __init__(self, user, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.user = user
+
+    def is_valid(self):
+        valid = super().is_valid()
+        if valid:
+            if ("step_node" not in self.data or not self.data["step_node"]) and (
+                "omnibox" not in self.data or len(self.data["omnibox"].strip()) == 0
+            ):
+                self.errors["__all__"] = self.error_class([str(_("At least one recipient is required"))])
+                return False
+        return valid
+
+    def clean(self):
+        cleaned = super().clean()
+        org = self.user.get_org()
+
+        if org.is_suspended:
+            raise ValidationError(
+                _("Sorry, your workspace is currently suspended. To enable sending messages, please contact support.")
+            )
+        if org.is_flagged:
+            raise ValidationError(
+                _("Sorry, your workspace is currently flagged. To enable sending messages, please contact support.")
+            )
+        return cleaned
+
+
+class InboxView(OrgPermsMixin, BulkActionMixin, SmartListView):
+    """
+    Base class for inbox views with message folders and labels listed by the side
+    """
+
+    refresh = 10000
+    add_button = True
+    system_label = None
+    fields = ("from", "message", "received")
+    search_fields = ("text__icontains", "contact__name__icontains", "contact__urns__path__icontains")
+    paginate_by = 100
+    allow_export = False
+    show_channel_logs = False
+    bulk_actions = ()
+    bulk_action_permissions = {"resend": "msgs.broadcast_send", "delete": "msgs.msg_update"}
+
+    def derive_label(self):
+        return self.system_label
+
+    def derive_export_url(self):
+        redirect = urlquote_plus(self.request.get_full_path())
+        label = self.derive_label()
+        label_id = label.uuid if isinstance(label, Label) else label
+        return "%s?l=%s&redirect=%s" % (reverse("msgs.msg_export"), label_id, redirect)
+
+    def pre_process(self, request, *args, **kwargs):
+        if self.system_label:
+            org = request.user.get_org()
+            self.queryset = SystemLabel.get_queryset(org, self.system_label)
+
+    def get_queryset(self, **kwargs):
+        queryset = super().get_queryset(**kwargs)
+
+        # if we are searching, limit to last 90
+        if "search" in self.request.GET:
+            last_90 = timezone.now() - timedelta(days=90)
+            queryset = queryset.filter(created_on__gte=last_90)
+
+        return queryset.order_by("-created_on", "-id").distinct("created_on", "id")
+
+    def get_bulk_action_labels(self):
+        return self.get_user().get_org().msgs_labels.all()
+
+    def get_context_data(self, **kwargs):
+        org = self.request.user.get_org()
+        counts = SystemLabel.get_counts(org)
+
+        label = self.derive_label()
+
+        # if there isn't a search filtering the queryset, we can replace the count function with a pre-calculated value
+        if "search" not in self.request.GET:
+            if isinstance(label, Label) and not label.is_folder():
+                patch_queryset_count(self.object_list, label.get_visible_count)
+            elif isinstance(label, str):
+                patch_queryset_count(self.object_list, lambda: counts[label])
+
+        context = super().get_context_data(**kwargs)
+
+        folders = [
+            dict(count=counts[SystemLabel.TYPE_INBOX], label=_("Inbox"), url=reverse("msgs.msg_inbox")),
+            dict(count=counts[SystemLabel.TYPE_FLOWS], label=_("Flows"), url=reverse("msgs.msg_flow")),
+            dict(count=counts[SystemLabel.TYPE_ARCHIVED], label=_("Archived"), url=reverse("msgs.msg_archived")),
+            dict(count=counts[SystemLabel.TYPE_OUTBOX], label=_("Outbox"), url=reverse("msgs.msg_outbox")),
+            dict(count=counts[SystemLabel.TYPE_SENT], label=_("Sent"), url=reverse("msgs.msg_sent")),
+            dict(count=counts[SystemLabel.TYPE_CALLS], label=_("Calls"), url=reverse("channels.channelevent_calls")),
+            dict(
+                count=counts[SystemLabel.TYPE_SCHEDULED],
+                label=_("Schedules"),
+                url=reverse("msgs.broadcast_schedule_list"),
+            ),
+            dict(count=counts[SystemLabel.TYPE_FAILED], label=_("Failed"), url=reverse("msgs.msg_failed")),
+        ]
+
+        context["org"] = org
+        context["folders"] = folders
+        context["labels"] = Label.get_hierarchy(org)
+        context["has_messages"] = (
+            any(counts.values()) or Archive.objects.filter(org=org, archive_type=Archive.TYPE_MSG).exists()
+        )
+        context["send_form"] = SendMessageForm(self.request.user)
+        context["current_label"] = label
+        context["export_url"] = self.derive_export_url()
+        context["show_channel_logs"] = self.show_channel_logs
+        context["start_date"] = org.get_delete_date(archive_type=Archive.TYPE_MSG)
+
+        # if refresh was passed in, increase it by our normal refresh time
+        previous_refresh = self.request.GET.get("refresh")
+        if previous_refresh:
+            context["refresh"] = int(previous_refresh) + self.derive_refresh()
+
+        return context
+
+    def get_gear_links(self):
+        links = []
+        if self.allow_export and self.has_org_perm("msgs.msg_export"):
+            links.append(
+                dict(
+                    id="export-messages",
+                    title=_("Download"),
+                    href=self.derive_export_url(),
+                    modax=_("Download Messages"),
+                )
+            )
+        return links
+
+
+class BroadcastForm(forms.ModelForm):
+    message = forms.CharField(
+        required=True,
+        widget=CompletionTextarea(attrs={"placeholder": _("Hi @contact.name!")}),
+        max_length=Broadcast.MAX_TEXT_LEN,
+    )
+
+    omnibox = JSONField(
+        label=_("Recipients"),
+        required=False,
+        help_text=_("The contacts to send the message to"),
+        widget=OmniboxChoice(
+            attrs={
+                "placeholder": _("Recipients, enter contacts or groups"),
+                "groups": True,
+                "contacts": True,
+                "urns": True,
+            }
+        ),
+    )
+
+    def is_valid(self):
+        valid = super().is_valid()
+        if valid:
+            if "omnibox" not in self.data or len(self.data["omnibox"].strip()) == 0:  # pragma: needs cover
+                self.errors["__all__"] = self.error_class([_("At least one recipient is required")])
+                return False
+
+        return valid
+
+    class Meta:
+        model = Broadcast
+        fields = "__all__"
+
+
+class BroadcastCRUDL(SmartCRUDL):
+    actions = ("send", "update", "schedule_read", "schedule_list")
+    model = Broadcast
+
+    class ScheduleRead(FormaxMixin, OrgObjPermsMixin, SmartReadView):
+        title = _("Schedule Message")
+
+        def derive_title(self):
+            return _("Scheduled Message")
+
+        def get_context_data(self, **kwargs):
+            context = super().get_context_data(**kwargs)
+            context["object_list"] = self.get_object().children.all()
+            return context
+
+        def derive_formax_sections(self, formax, context):
+            if self.has_org_perm("msgs.broadcast_update"):
+                formax.add_section(
+                    "contact", reverse("msgs.broadcast_update", args=[self.object.pk]), icon="icon-megaphone"
+                )
+
+            if self.has_org_perm("schedules.schedule_update"):
+                formax.add_section(
+                    "schedule",
+                    reverse("schedules.schedule_update", args=[self.object.schedule.pk]),
+                    icon="icon-calendar",
+                    action="formax",
+                )
+
+    class Update(OrgObjPermsMixin, ComponentFormMixin, SmartUpdateView):
+        form_class = BroadcastForm
+        fields = ("message", "omnibox")
+        field_config = {"restrict": {"label": ""}, "omnibox": {"label": ""}, "message": {"label": "", "help": ""}}
+        success_message = ""
+        success_url = "msgs.broadcast_schedule_list"
+
+        def derive_initial(self):
+            org = self.object.org
+            results = [*self.object.groups.all(), *self.object.contacts.all()]
+            selected = omnibox_results_to_dict(org, results, version="2")
+            message = self.object.text[self.object.base_language]
+            return dict(message=message, omnibox=selected)
+
+        def save(self, *args, **kwargs):
+            form = self.form
+            broadcast = self.object
+            org = broadcast.org
+
+            # save off our broadcast info
+            omnibox = omnibox_deserialize(org, self.form.cleaned_data["omnibox"])
+
+            # set our new message
+            broadcast.text = {broadcast.base_language: form.cleaned_data["message"]}
+            broadcast.update_recipients(groups=omnibox["groups"], contacts=omnibox["contacts"], urns=omnibox["urns"])
+
+            broadcast.save()
+            return broadcast
+
+    class ScheduleList(InboxView):
+        refresh = 30000
+        title = _("Scheduled Messages")
+        fields = ("contacts", "msgs", "sent", "status")
+        search_fields = ("text__icontains", "contacts__urns__path__icontains")
+        template_name = "msgs/broadcast_schedule_list.haml"
+        default_order = ("schedule__status", "schedule__next_fire", "-created_on")
+        system_label = SystemLabel.TYPE_SCHEDULED
+
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            return qs.select_related("org", "schedule").order_by("-created_on")
+
+    class Send(OrgPermsMixin, ModalMixin, SmartFormView):
+        title = _("Send Message")
+        form_class = SendMessageForm
+        fields = ("omnibox", "text", "schedule", "step_node")
+        success_url = "@msgs.msg_inbox"
+        submit_button_name = _("Send Message")
+
+        def derive_initial(self):
+            initial = super().derive_initial()
+            org = self.request.user.get_org()
+
+            urn_ids = [_ for _ in self.request.GET.get("u", "").split(",") if _]
+            msg_ids = [_ for _ in self.request.GET.get("m", "").split(",") if _]
+            contact_uuids = [_ for _ in self.request.GET.get("c", "").split(",") if _]
+
+            if msg_ids or contact_uuids or urn_ids:
+                params = {}
+                if len(msg_ids) > 0:
+                    params["m"] = ",".join(msg_ids)
+                if len(contact_uuids) > 0:
+                    params["c"] = ",".join(contact_uuids)
+                if len(urn_ids) > 0:
+                    params["u"] = ",".join(urn_ids)
+
+                results = omnibox_query(org, **params)
+                initial["omnibox"] = omnibox_results_to_dict(org, results, version=2)
+
+            initial["step_node"] = self.request.GET.get("step_node", None)
+            return initial
+
+        def derive_fields(self):
+            if self.request.GET.get("step_node"):
+                return ("text", "step_node")
+            else:
+                return super().derive_fields()
+
+        def get_context_data(self, **kwargs):
+            context = super().get_context_data(**kwargs)
+            context["recipient_count"] = int(self.request.GET.get("count", 0))
+            return context
+
+        def pre_process(self, *args, **kwargs):
+            if self.request.method == "POST":
+                response = super().pre_process(*args, **kwargs)
+                org = self.request.user.get_org()
+                # can this org send to any URN schemes?
+                if not org.get_schemes(Channel.ROLE_SEND):
+                    return HttpResponseBadRequest(_("You must add a phone number before sending messages"))
+                return response
+
+        def form_valid(self, form):
+            self.form = form
+            user = self.request.user
+            org = user.get_org()
+
+            step_uuid = self.form.cleaned_data.get("step_node", None)
+            text = self.form.cleaned_data["text"]
+            has_schedule = False
+
+            if step_uuid:
+                from .tasks import send_to_flow_node
+
+                get_params = {k: v for k, v in self.request.GET.items()}
+                get_params.update({"s": step_uuid})
+                send_to_flow_node.delay(org.pk, user.pk, text, **get_params)
+            else:
+
+                omnibox = omnibox_deserialize(org, self.form.cleaned_data["omnibox"])
+                has_schedule = self.form.cleaned_data["schedule"]
+
+                groups = list(omnibox["groups"])
+                contacts = list(omnibox["contacts"])
+                urns = list(omnibox["urns"])
+
+                schedule = Schedule.create_blank_schedule(org, user) if has_schedule else None
+                broadcast = Broadcast.create(
+                    org,
+                    user,
+                    text,
+                    groups=groups,
+                    contacts=contacts,
+                    urns=urns,
+                    schedule=schedule,
+                    status=QUEUED,
+                    template_state=Broadcast.TEMPLATE_STATE_UNEVALUATED,
+                )
+
+                if not has_schedule:
+                    self.post_save(broadcast)
+                    super().form_valid(form)
+
+                analytics.track(
+                    self.request.user,
+                    "temba.broadcast_created",
+                    dict(contacts=len(contacts), groups=len(groups), urns=len(urns)),
+                )
+
+            if "HTTP_X_PJAX" in self.request.META:
+                success_url = "hide"
+                if has_schedule:
+                    success_url = reverse("msgs.broadcast_schedule_read", args=[broadcast.pk])
+
+                response = self.render_to_response(self.get_context_data())
+                response["Temba-Success"] = success_url
+                return response
+
+            return HttpResponseRedirect(self.get_success_url())
+
+        def post_save(self, obj):
+            on_transaction_commit(lambda: obj.send_async())
+            return obj
+
+        def get_form_kwargs(self):
+            kwargs = super().get_form_kwargs()
+            kwargs["user"] = self.request.user
+            return kwargs
+
+
+class TestMessageForm(forms.Form):
+    channel = TembaChoiceField(Channel.objects.filter(id__lt=0), help_text=_("Which channel will deliver the message"))
+    urn = forms.CharField(max_length=14, help_text=_("The URN of the contact delivering this message"))
+    text = forms.CharField(max_length=160, widget=forms.Textarea, help_text=_("The message that is being delivered"))
+
+    def __init__(self, *args, **kwargs):  # pragma: needs cover
+        org = kwargs["org"]
+        del kwargs["org"]
+
+        super().__init__(*args, **kwargs)
+        self.fields["channel"].queryset = Channel.objects.filter(org=org, is_active=True)
+
+
+class ExportForm(Form):
+    LABEL_CHOICES = ((0, _("Just this label")), (1, _("All messages")))
+
+    SYSTEM_LABEL_CHOICES = ((0, _("Just this folder")), (1, _("All messages")))
+
+    export_all = forms.ChoiceField(
+        choices=(), label=_("Selection"), initial=0, widget=SelectWidget(attrs={"widget_only": True})
+    )
+
+    start_date = forms.DateField(
+        required=False,
+        help_text=_("Leave blank for the oldest message"),
+        widget=InputWidget(attrs={"datepicker": True, "hide_label": True, "placeholder": _("Start Date")}),
+    )
+
+    end_date = forms.DateField(
+        required=False,
+        help_text=_("Leave blank for the latest message"),
+        widget=InputWidget(attrs={"datepicker": True, "hide_label": True, "placeholder": _("End Date")}),
+    )
+
+    groups = forms.ModelMultipleChoiceField(
+        queryset=ContactGroup.user_groups.none(),
+        required=False,
+        label=_("Groups"),
+        widget=SelectMultipleWidget(
+            attrs={"widget_only": True, "placeholder": _("Optional: Choose groups to show in your export")}
+        ),
+    )
+
+    def __init__(self, user, label, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.user = user
+
+        self.fields["export_all"].choices = self.LABEL_CHOICES if label else self.SYSTEM_LABEL_CHOICES
+
+        self.fields["groups"].queryset = ContactGroup.user_groups.filter(org=self.user.get_org(), is_active=True)
+        self.fields["groups"].help_text = _(
+            "Export only messages from these contact groups. " "(Leave blank to export all messages)."
+        )
+
+    def clean(self):
+        cleaned_data = super().clean()
+        start_date = cleaned_data.get("start_date")
+        end_date = cleaned_data.get("end_date")
+
+        if start_date and start_date > date.today():  # pragma: needs cover
+            raise forms.ValidationError(_("Start date can't be in the future."))
+
+        if end_date and start_date and end_date < start_date:  # pragma: needs cover
+            raise forms.ValidationError(_("End date can't be before start date"))
+
+        return cleaned_data
+
+
+class MsgCRUDL(SmartCRUDL):
+    model = Msg
+    actions = ("inbox", "flow", "archived", "outbox", "sent", "failed", "filter", "export")
+
+    class Export(ModalMixin, OrgPermsMixin, SmartFormView):
+
+        form_class = ExportForm
+        submit_button_name = "Export"
+        success_url = "@msgs.msg_inbox"
+
+        def derive_label(self):
+            # label is either a UUID of a Label instance (36 chars) or a system label type code (1 char)
+            label_id = self.request.GET["l"]
+            if len(label_id) == 1:
+                return label_id, None
+            else:
+                return None, Label.all_objects.get(org=self.request.user.get_org(), uuid=label_id)
+
+        def get_success_url(self):
+            redirect = self.request.GET.get("redirect")
+            if redirect and not is_safe_url(redirect, self.request.get_host()):
+                redirect = None
+
+            return redirect or reverse("msgs.msg_inbox")
+
+        def form_invalid(self, form):  # pragma: needs cover
+            if "_format" in self.request.GET and self.request.GET["_format"] == "json":
+                return HttpResponse(
+                    json.dumps(dict(status="error", errors=form.errors)), content_type="application/json", status=400
+                )
+            else:
+                return super().form_invalid(form)
+
+        def form_valid(self, form):
+            user = self.request.user
+            org = user.get_org()
+
+            export_all = bool(int(form.cleaned_data["export_all"]))
+            groups = form.cleaned_data["groups"]
+            start_date = form.cleaned_data["start_date"]
+            end_date = form.cleaned_data["end_date"]
+
+            system_label, label = (None, None) if export_all else self.derive_label()
+
+            # is there already an export taking place?
+            existing = ExportMessagesTask.get_recent_unfinished(org)
+            if existing:
+                messages.info(
+                    self.request,
+                    _(
+                        "There is already an export in progress, started by %s. You must wait "
+                        "for that export to complete before starting another." % existing.created_by.username
+                    ),
+                )
+
+            # otherwise, off we go
+            else:
+                export = ExportMessagesTask.create(
+                    org,
+                    user,
+                    system_label=system_label,
+                    label=label,
+                    groups=groups,
+                    start_date=start_date,
+                    end_date=end_date,
+                )
+
+                on_transaction_commit(lambda: export_messages_task.delay(export.id))
+
+                if not getattr(settings, "CELERY_ALWAYS_EAGER", False):  # pragma: needs cover
+                    messages.info(
+                        self.request,
+                        _("We are preparing your export. We will e-mail you at %s when " "it is ready.")
+                        % self.request.user.username,
+                    )
+
+                else:
+                    dl_url = reverse("assets.download", kwargs=dict(type="message_export", pk=export.pk))
+                    messages.info(
+                        self.request,
+                        _("Export complete, you can find it here: %s (production users " "will get an email)")
+                        % dl_url,
+                    )
+
+            messages.success(self.request, self.derive_success_message())
+
+            if "HTTP_X_PJAX" not in self.request.META:
+                return HttpResponseRedirect(self.get_success_url())
+            else:  # pragma: no cover
+                response = self.render_modal_response(form)
+                response["REDIRECT"] = self.get_success_url()
+                return response
+
+        def get_form_kwargs(self):
+            kwargs = super().get_form_kwargs()
+            kwargs["user"] = self.request.user
+            kwargs["label"] = self.derive_label()[1]
+            return kwargs
+
+    class Inbox(InboxView):
+        title = _("Inbox")
+        template_name = "msgs/message_box.haml"
+        system_label = SystemLabel.TYPE_INBOX
+        bulk_actions = ("archive", "label")
+        allow_export = True
+
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            return qs.prefetch_related("labels").select_related("contact")
+
+    class Flow(InboxView):
+        title = _("Flow Messages")
+        template_name = "msgs/message_box.haml"
+        system_label = SystemLabel.TYPE_FLOWS
+        bulk_actions = ("label",)
+        allow_export = True
+
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            return qs.prefetch_related("labels").select_related("contact")
+
+    class Archived(InboxView):
+        title = _("Archived")
+        template_name = "msgs/msg_archived.haml"
+        system_label = SystemLabel.TYPE_ARCHIVED
+        bulk_actions = ("restore", "label", "delete")
+        allow_export = True
+
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            return qs.prefetch_related("labels").select_related("contact")
+
+    class Outbox(InboxView):
+        title = _("Outbox Messages")
+        template_name = "msgs/msg_outbox.haml"
+        system_label = SystemLabel.TYPE_OUTBOX
+        bulk_actions = ()
+        allow_export = True
+        show_channel_logs = True
+
+        def get_context_data(self, **kwargs):
+            context = super().get_context_data(**kwargs)
+
+            # stuff in any pending broadcasts
+            context["pending_broadcasts"] = (
+                Broadcast.objects.filter(
+                    org=self.request.user.get_org(), status__in=[QUEUED, INITIALIZING], schedule=None
+                )
+                .select_related("org")
+                .prefetch_related("groups", "contacts", "urns")
+                .order_by("-created_on")
+            )
+            return context
+
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            return qs.prefetch_related("channel_logs").select_related("contact")
+
+    class Sent(InboxView):
+        title = _("Sent Messages")
+        template_name = "msgs/msg_sent.haml"
+        system_label = SystemLabel.TYPE_SENT
+        bulk_actions = ()
+        allow_export = True
+        show_channel_logs = True
+
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            return qs.prefetch_related("channel_logs").select_related("contact")
+
+    class Failed(InboxView):
+        title = _("Failed Outgoing Messages")
+        template_name = "msgs/msg_failed.haml"
+        success_message = ""
+        system_label = SystemLabel.TYPE_FAILED
+        allow_export = True
+        show_channel_logs = True
+
+        def get_bulk_actions(self):
+            return () if self.request.org.is_suspended else ("resend",)
+
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            return qs.prefetch_related("channel_logs").select_related("contact")
+
+    class Filter(InboxView):
+        template_name = "msgs/msg_filter.haml"
+        bulk_actions = ("label",)
+
+        def derive_title(self, *args, **kwargs):
+            return self.derive_label().name
+
+        def get_gear_links(self):
+            links = []
+
+            label = self.derive_label()
+            if self.has_org_perm("msgs.msg_update"):
+                if label.is_folder():
+                    links.append(
+                        dict(
+                            id="update-label",
+                            title=_("Edit Folder"),
+                            href=reverse("msgs.label_update", args=[label.pk]),
+                            modax=_("Edit Folder"),
+                        )
+                    )
+                else:
+                    links.append(
+                        dict(
+                            id="update-label",
+                            title=_("Edit Label"),
+                            href=reverse("msgs.label_update", args=[label.pk]),
+                            modax=_("Edit Label"),
+                        )
+                    )
+
+            if self.has_org_perm("msgs.msg_export"):
+                links.append(
+                    dict(
+                        id="export-messages",
+                        title=_("Download"),
+                        href=self.derive_export_url(),
+                        modax=_("Download Messages"),
+                    )
+                )
+
+            if self.has_org_perm("msgs.broadcast_send"):
+                links.append(
+                    dict(title=_("Send All"), style="btn-primary", href="#", js_class="filter-send-all-send-button")
+                )
+
+            if label.is_folder():
+                if self.has_org_perm("msgs.label_delete_folder"):
+                    links.append(
+                        dict(
+                            id="delete-folder",
+                            title=_("Delete Folder"),
+                            href=reverse("msgs.label_delete_folder", args=[label.id]),
+                            modax=_("Delete Folder"),
+                        )
+                    )
+            else:
+                if self.has_org_perm("msgs.label_delete"):
+                    links.append(
+                        dict(
+                            id="delete-label",
+                            title=_("Delete Label"),
+                            href=reverse("msgs.label_delete", args=[label.uuid]),
+                            modax=_("Delete Label"),
+                        )
+                    )
+
+            return links
+
+        @classmethod
+        def derive_url_pattern(cls, path, action):
+            return r"^%s/%s/(?P<label>[^/]+)/$" % (path, action)
+
+        def derive_label(self):
+            return self.request.user.get_org().msgs_labels.get(uuid=self.kwargs["label"])
+
+        def get_queryset(self, **kwargs):
+            qs = super().get_queryset(**kwargs)
+            qs = self.derive_label().filter_messages(qs).filter(visibility=Msg.VISIBILITY_VISIBLE)
+
+            return qs.prefetch_related("labels").select_related("contact")
+
+
+class BaseLabelForm(forms.ModelForm):
+    def clean_name(self):
+        name = self.cleaned_data["name"]
+
+        if not Label.is_valid_name(name):
+            raise forms.ValidationError(_("Name must not be blank or begin with punctuation"))
+
+        existing_id = self.existing.pk if self.existing else None
+        if Label.all_objects.filter(org=self.org, name__iexact=name, is_active=True).exclude(pk=existing_id).exists():
+            raise forms.ValidationError(_("Name must be unique"))
+
+        labels_count = Label.all_objects.filter(org=self.org, is_active=True).count()
+        if labels_count >= Label.MAX_ORG_LABELS:
+            raise forms.ValidationError(
+                _(
+                    "This org has %(count)d labels and the limit is %(limit)d. "
+                    "You must delete existing ones before you can "
+                    "create new ones." % dict(count=labels_count, limit=Label.MAX_ORG_LABELS)
+                )
+            )
+
+        return name
+
+    class Meta:
+        model = Label
+        fields = ("name",)
+        labels = {"name": _("Name")}
+        widgets = {"name": InputWidget()}
+
+
+class LabelForm(BaseLabelForm):
+    folder = forms.ModelChoiceField(
+        Label.folder_objects.none(),
+        required=False,
+        label=_("Folder"),
+        widget=SelectWidget(attrs={"placeholder": _("Select folder")}),
+        help_text=_("Optional folder which can be used to group related labels."),
+    )
+
+    messages = forms.CharField(required=False, widget=forms.HiddenInput)
+
+    def __init__(self, *args, **kwargs):
+        self.org = kwargs.pop("org")
+        self.existing = kwargs.pop("object", None)
+
+        super().__init__(*args, **kwargs)
+
+        self.fields["folder"].queryset = Label.folder_objects.filter(org=self.org, is_active=True)
+
+    class Meta(BaseLabelForm.Meta):
+        fields = ("name", "folder")
+
+
+class FolderForm(BaseLabelForm):
+    def __init__(self, *args, **kwargs):
+        self.org = kwargs.pop("org")
+        self.existing = kwargs.pop("object", None)
+
+        super().__init__(*args, **kwargs)
+
+
+class LabelCRUDL(SmartCRUDL):
+    model = Label
+    actions = ("create", "create_folder", "update", "delete", "delete_folder", "list")
+
+    class List(OrgPermsMixin, SmartListView):
+        paginate_by = None
+        default_order = ("name",)
+
+        def derive_queryset(self, **kwargs):
+            return Label.label_objects.filter(org=self.request.user.get_org())
+
+        def render_to_response(self, context, **response_kwargs):
+            results = [dict(id=l.uuid, text=l.name) for l in context["object_list"]]
+            return HttpResponse(json.dumps(results), content_type="application/json")
+
+    class Create(ModalMixin, OrgPermsMixin, SmartCreateView):
+        fields = ("name", "folder", "messages")
+        success_url = "hide"
+        form_class = LabelForm
+        success_message = ""
+        submit_button_name = _("Create")
+
+        def get_form_kwargs(self):
+            kwargs = super().get_form_kwargs()
+            kwargs["org"] = self.request.user.get_org()
+            return kwargs
+
+        def save(self, obj):
+            user = self.request.user
+            self.object = Label.get_or_create(user.get_org(), user, obj.name, obj.folder)
+
+        def post_save(self, obj, *args, **kwargs):
+            obj = super().post_save(obj, *args, **kwargs)
+            if self.form.cleaned_data["messages"]:  # pragma: needs cover
+                msg_ids = [int(m) for m in self.form.cleaned_data["messages"].split(",") if m.isdigit()]
+                messages = Msg.objects.filter(org=obj.org, pk__in=msg_ids)
+                if messages:
+                    obj.toggle_label(messages, add=True)
+
+            return obj
+
+    class CreateFolder(ModalMixin, OrgPermsMixin, SmartCreateView):
+        fields = ("name",)
+        success_url = "@msgs.msg_inbox"
+        form_class = FolderForm
+        success_message = ""
+        submit_button_name = _("Create")
+
+        def get_form_kwargs(self):
+            kwargs = super().get_form_kwargs()
+            kwargs["org"] = self.request.user.get_org()
+            return kwargs
+
+        def save(self, obj):
+            user = self.request.user
+            self.object = Label.get_or_create_folder(user.get_org(), user, obj.name)
+
+    class Update(ModalMixin, OrgObjPermsMixin, SmartUpdateView):
+        success_url = "uuid@msgs.msg_filter"
+        success_message = ""
+
+        def get_form_kwargs(self):
+            kwargs = super().get_form_kwargs()
+            kwargs["org"] = self.request.user.get_org()
+            kwargs["object"] = self.get_object()
+            return kwargs
+
+        def get_form_class(self):
+            return FolderForm if self.get_object().is_folder() else LabelForm
+
+        def derive_title(self):
+            return _("Update Folder") if self.get_object().is_folder() else _("Update Label")
+
+        def derive_fields(self):
+            return ("name",) if self.get_object().is_folder() else ("name", "folder")
+
+    class Delete(DependencyDeleteModal):
+        cancel_url = "@msgs.msg_inbox"
+        success_url = "@msgs.msg_inbox"
+        success_message = _("Your label has been deleted.")
+
+    class DeleteFolder(ModalMixin, OrgObjPermsMixin, SmartDeleteView):
+        success_url = "@msgs.msg_inbox"
+        redirect_url = "@msgs.msg_inbox"
+        cancel_url = "@msgs.msg_inbox"
+        success_message = _("Your label folder has been deleted.")
+        fields = ("uuid",)
+        submit_button_name = _("Delete")
+
+        def post(self, request, *args, **kwargs):
+            self.object = self.get_object()
+
+            # don't actually release if a label has been added
+            if self.object.has_child_labels():
+                return self.render_to_response(self.get_context_data())
+
+            self.object.release(self.request.user)
+            response = HttpResponse()
+            response["Temba-Success"] = self.get_success_url()
+            return response

--- a/docker/customizations/any/temba/msgs/views.py
+++ b/docker/customizations/any/temba/msgs/views.py
@@ -210,6 +210,7 @@ class InboxView(OrgPermsMixin, BulkActionMixin, SmartListView):
             )
         return links
 
+from engage.msgs.inboxview import BaseInboxView
 
 class BroadcastForm(forms.ModelForm):
     message = forms.CharField(
@@ -304,7 +305,7 @@ class BroadcastCRUDL(SmartCRUDL):
             broadcast.save()
             return broadcast
 
-    class ScheduleList(InboxView):
+    class ScheduleList(BaseInboxView):
         refresh = 30000
         title = _("Scheduled Messages")
         fields = ("contacts", "msgs", "sent", "status")
@@ -602,7 +603,7 @@ class MsgCRUDL(SmartCRUDL):
             kwargs["label"] = self.derive_label()[1]
             return kwargs
 
-    class Inbox(InboxView):
+    class Inbox(BaseInboxView):
         title = _("Inbox")
         template_name = "msgs/message_box.haml"
         system_label = SystemLabel.TYPE_INBOX
@@ -613,7 +614,7 @@ class MsgCRUDL(SmartCRUDL):
             qs = super().get_queryset(**kwargs)
             return qs.prefetch_related("labels").select_related("contact")
 
-    class Flow(InboxView):
+    class Flow(BaseInboxView):
         title = _("Flow Messages")
         template_name = "msgs/message_box.haml"
         system_label = SystemLabel.TYPE_FLOWS
@@ -624,7 +625,7 @@ class MsgCRUDL(SmartCRUDL):
             qs = super().get_queryset(**kwargs)
             return qs.prefetch_related("labels").select_related("contact")
 
-    class Archived(InboxView):
+    class Archived(BaseInboxView):
         title = _("Archived")
         template_name = "msgs/msg_archived.haml"
         system_label = SystemLabel.TYPE_ARCHIVED
@@ -635,7 +636,7 @@ class MsgCRUDL(SmartCRUDL):
             qs = super().get_queryset(**kwargs)
             return qs.prefetch_related("labels").select_related("contact")
 
-    class Outbox(InboxView):
+    class Outbox(BaseInboxView):
         title = _("Outbox Messages")
         template_name = "msgs/msg_outbox.haml"
         system_label = SystemLabel.TYPE_OUTBOX
@@ -661,7 +662,7 @@ class MsgCRUDL(SmartCRUDL):
             qs = super().get_queryset(**kwargs)
             return qs.prefetch_related("channel_logs").select_related("contact")
 
-    class Sent(InboxView):
+    class Sent(BaseInboxView):
         title = _("Sent Messages")
         template_name = "msgs/msg_sent.haml"
         system_label = SystemLabel.TYPE_SENT
@@ -673,7 +674,7 @@ class MsgCRUDL(SmartCRUDL):
             qs = super().get_queryset(**kwargs)
             return qs.prefetch_related("channel_logs").select_related("contact")
 
-    class Failed(InboxView):
+    class Failed(BaseInboxView):
         title = _("Failed Outgoing Messages")
         template_name = "msgs/msg_failed.haml"
         success_message = ""
@@ -688,7 +689,7 @@ class MsgCRUDL(SmartCRUDL):
             qs = super().get_queryset(**kwargs)
             return qs.prefetch_related("channel_logs").select_related("contact")
 
-    class Filter(InboxView):
+    class Filter(BaseInboxView):
         template_name = "msgs/msg_filter.haml"
         bulk_actions = ("label",)
 

--- a/docker/customizations/any/templates/contacts/contact_read.haml
+++ b/docker/customizations/any/templates/contacts/contact_read.haml
@@ -17,7 +17,9 @@
       -if not user_org.is_anon
         -#if urn.sendable
         %temba-modax.text-base{ id:'send-via-{{urn.scheme}}', header:'Send Message', endpoint:"{% url 'msgs.broadcast_send' %}?u={{urn.id}}"}
-          .hover-linked{class:"glyph {{urn|urn_icon}}", style:"margin-top:0px"}
+          .send-via-btn.hover-linked{class:"glyph {{urn|urn_icon}}", style:"margin-top:0px"}
+            .tooltiptext
+              Send via {{urn.scheme}}
 
 -block subtitle
 

--- a/engage/hamls/includes/org.haml
+++ b/engage/hamls/includes/org.haml
@@ -35,7 +35,7 @@
             -else
               %option.org{value:'{{ org.pk }}', class:'state-ok'}
                 {{ org.name }}
-  {% else %}
+  {% elif user_org.name|length > 0 %}
     #org-name.org
       {{ user_org.name }}
   {% endif %}

--- a/engage/hamls/msgs/message_box.haml
+++ b/engage/hamls/msgs/message_box.haml
@@ -1,0 +1,284 @@
+-extends "smartmin/list.html"
+-load smartmin sms temba compress contacts i18n humanize
+
+-block extra-style
+  {{block.super}}
+  :css
+    temba-button {
+      display: block;
+    }
+
+-block page-title
+  {{title}}
+
+-block title-icon
+  %span.title-icon
+    .glyph.icon-inbox
+
+-block page-top
+
+-block content
+
+  #numeric-form.hide
+    %form
+      %label
+        -trans "Numeric Value:"
+      %input#number{type:"text"}
+    .error
+
+  #pjax
+    -block pjax
+      .lp-frame
+        .left
+          .flex.flex-col
+            -if org_perms.msgs.broadcast_send
+              .w-64.mr-5
+                %temba-modax#send-message-modal{ header:'{% trans "Send Message" %}', endpoint:"{% url 'msgs.broadcast_send' %}" }
+                  .button-primary.block(onclick="handleSendMessageClicked()")
+                    -trans "Send Message"
+
+            .lp-nav.upper
+              - for folder in folders
+                .lp-nav-item{'class': '{% if request.path == folder.url %}font-normal{% endif %}' }
+                  .name{onclick:"goto(event)", href:'{{folder.url}}'}
+                    {{folder.label}}
+                  .count{onclick:"goto(event)", href:'{{folder.url}}'}
+                    {{ folder.count | intcomma }}
+
+            -if labels
+              .lp-nav.lower
+                .font-normal.uppercase.text-xs.text-gray-500.pb-1
+                  - trans "Labels"
+                .inner-scroll
+                  -for node in labels
+                    -if node.obj.is_folder
+                      .lp-nav-item{ class:'{% if current_label.id == node.obj.id %}font-normal{% endif %}' }
+                        .name{onclick:"goto(event)", 'href':'{% url "msgs.msg_filter" node.obj.uuid %}'}
+                          {{ node.obj.name }}
+                        -if node.children
+                          .count.-mr-1.text-gray-400
+                            -if current_label.id == node.obj.id or current_label.folder_id == node.obj.id
+                              .glyph.icon-arrow-down-2{onclick:"goto(event)", 'href':'{% url "msgs.msg_filter" node.obj.uuid %}'}
+                            -else
+                              .glyph.icon-arrow-right-8{onclick:"goto(event)", 'href':'{% url "msgs.msg_filter" node.obj.uuid %}'}
+
+                      -if current_label.id == node.obj.id or current_label.folder_id == node.obj.id
+                        .pl-2.mt-1.level2.font-light
+                          -for child in node.children
+                            .lp-nav-item{ class:'{% if current_label.id == child.obj.id %}font-normal{% endif %}' }
+                              .name{onclick:"goto(event)",  href:"{% url 'msgs.msg_filter' child.obj.uuid %}" }
+                                {{ child.obj.name }}
+                              .count{onclick:"goto(event)", href:"{% url 'msgs.msg_filter' child.obj.uuid %}" }
+                                {{ child.count | intcomma }}
+                  -for node in labels
+                    -if not node.obj.is_folder
+                      .lp-nav-item{ class:'{% if current_label.id == node.obj.id %}font-normal{% endif %}' }
+                        .name{onclick:"goto(event)", href:"{% url 'msgs.msg_filter' node.obj.uuid %}", class:'{% if current_label.id == node.obj.id %}font-normal active{% endif %}' }
+                          {{ node.obj.name }} 
+                        .count{onclick:"goto(event)", href:"{% url 'msgs.msg_filter' node.obj.uuid %}", class:'{% if current_label.id == node.obj.id %}font-normal active{% endif %}' }
+                          {{ node.count | intcomma }}
+
+            .flex-grow
+              -if org_perms.msgs.label_create
+                %temba-modax#create-label-modal{ header:'{% trans "Create Label" %}', endpoint:"{% url 'msgs.label_create' %}", "-temba-loaded": "handleCreateLabelModalLoaded", "-temba-submitted": "handleCreateLabelModalSubmitted"}
+                  .button-light.block.mt-3
+                    - trans "Create Label"
+                  
+              -if org_perms.msgs.label_create_folder
+                %temba-modax{ header:'{% trans "Create Folder" %}', endpoint:"{% url 'msgs.label_create_folder' %}"}
+                  .button-light.block.mt-3
+                    -trans "Create Folder"
+
+        -if has_messages
+          .right
+            .flex.w-full.items-end.mb-4
+              -block action-buttons
+                -if org_perms.msgs.msg_update
+                  .action-buttons.list-buttons-container.h-full.mr-2.flex-grow
+                    .list-buttons.flex.items-center.-mx-2.h-full
+                      - if 'unlabel' in actions
+                        .button-action.object-btn-unlabel
+                          .glyph.icon-box
+                          -trans "Remove Label"
+
+                      - if 'archive' in actions
+                        .button-action.object-btn-archive
+                          .-mt-1.mr-2.glyph.icon-box
+                          -trans "Archive"
+
+                      - if 'restore' in actions
+                        .button-action.object-btn-restore
+                          .-mt-1.mr-2.glyph.icon-download
+                          -trans "Restore"
+
+                      - if 'delete' in actions
+                        .button-action.object-btn-delete
+                          .-mt-1.mr-2.glyph.icon-remove
+                          -trans "Delete"
+
+                      - if 'resend' in actions
+                        .button-action.object-btn-resend
+                          .mt-1.mr-2.glyph.icon-loop.text-sm
+                          -trans "Resend"
+
+                      - if 'label' in actions
+                        .btn-group
+                          .button-action.dropdown-toggle{data-toggle:"dropdown"}
+                            .-mt-1.mr-2.glyph.icon-tag{style:"width:16px"}
+                            -trans "Label"
+
+                          %ul.dropdown-menu.label-menu.rounded-lg.border-none.px-4.py-3
+                            -for node in labels
+                              -if node.obj.is_folder and node.children
+                                %li.dropdown-submenu
+                                  .lbl-menu.object-btn-label.cursor-pointer{data-id:'{{node.obj.id}}'}
+                                    .flex.items-center.py-1.hover-linked
+                                      .icon-arrow-right-8.text-2xl.-ml-1.-mt-1.mr-1
+                                      .name.px-2
+                                        {{ node.obj.name }}
+                                  %ul.dropdown-menu.label-menu.border-none
+                                    - for child in node.children
+                                      %li
+                                        .lbl-menu.object-btn-label.px-4{data-id:'{{child.obj.id}}'}
+                                          .flex.items-center.py-1.hover-linked
+                                            .glyph.message-label.label-checkbox
+                                            .name.px-1
+                                              {{ child.obj.name }}
+                            -for node in labels
+                              -if not node.obj.is_folder
+                                %li
+                                  .lbl-menu.object-btn-label{data-id:'{{node.obj.id}}'}
+                                    .flex.items-center.py-1.hover-linked
+                                      .glyph.message-label.label-checkbox
+                                      .name.px-1
+                                        {{ node.obj.name }}
+
+                            - if org_perms.msgs.label_create
+                              - if labels
+                                %li.separator.-mx-4.border-b.my-3
+                              %li
+                                .lbl-menu.add-label.linked{onclick:"handleAddLabelClicked()"}
+                                  -trans "New Label..."
+              .flex-grow.ml-2.items-center
+                -block title-text
+                  .page-title.leading-tight
+                    {{title}}
+              .gear-links
+                -include "gear_links_include.haml"
+
+            %form#search-form.mb-4(method="get")
+              %temba-textinput.w-full(placeholder='{% trans "Search" %}' name="search" value="{{search}}")
+
+            -block message-list
+              %table.list.object-list.lined{class: '{% if org_perms.msgs.msg_update or org_perms.msgs.broadcast_send %}selectable{% endif %}'}
+                %tbody
+                  -for object in object_list
+                    %tr.sms.object-row{id: 'id-row-{{object.id}}', data-object-id:'{{ object.id }}',
+                                  data-sender-id:'{{object.contact.id}}', data-sender-uuid:'{{object.contact.uuid}}', onrowclick:'handleRowClick("{{object.contact.uuid}}")'}
+                      -if actions
+                        - if org_perms.msgs.msg_update or org_perms.msgs.broadcast_send
+                          %td.checkbox.sms.object-row-check
+                            %temba-checkbox{onclick:"handleRowSelection(this)"}
+                      %td.whitespace-nowrap
+                        {{ object.contact|short_name:user_org }}
+                      %td.w-full
+                        .flex.flex-wrap.flex-end.items-center.justify-end
+                          .flex-grow.inline
+                            {% get_value object 'text' %}
+                          .labels.flex.items-center.flex-wrap
+                            -if 'label' in actions
+                              -for label in object.labels.all
+                                .lbl.linked.ml-2{onclick:"goto(event, this)", href:"{% url 'msgs.msg_filter' label.uuid %}", data-id: '{{label.id}}'}                                
+                                  {{label.name}}
+
+                        -if object.attachments
+                          .value-attachments{ style:"margin-top: 5px" }
+                            - for attachment in object.attachments
+                              {% attachment_button attachment %}
+
+                      %td
+                        .flex.w-full.items-end.justify-end.pr-4
+                          .time.whitespace-nowrap
+                            {% short_datetime object.created_on %}
+
+                          -if show_channel_logs and not user_org.is_anon or perms.contacts.contact_break_anon
+                            .inline-block.text-gray-400.linked.ml-3
+                              {% channel_log_link object %}
+
+                  -if not object_list
+                    %tr.empty_list
+                      %td{ colspan:'99' }
+                        -trans "No messages"
+
+              - block paginator
+                -if object_list.count
+                  -block search-details
+                    .flex.mx-4.mt-3.mb-16
+                      .text-gray-700
+                        -if not paginator or paginator.num_pages <= 1                        
+                          -if search
+                            -blocktrans trimmed with results_count=paginator.count|intcomma count cc=paginator.count
+                              Found {{ results_count }} message in last 90 days matching <i>{{search}}</i>.
+                              -plural
+                                Found {{ results_count }} messages in last 90 days matching <i>{{search}}</i>.
+                          -else
+                            -if start_date
+                              -blocktrans trimmed with results_count=paginator.count|intcomma count cc=paginator.count
+                                {{ results_count }} message since {{ start_date}}.
+                                -plural
+                                  {{ results_count }} messages since {{ start_date}}.
+
+                        - else
+
+                          -if search
+                            -blocktrans trimmed with results_count=paginator.count|intcomma start=page_obj.start_index|intcomma end=page_obj.end_index|intcomma count cc=paginator.count 
+                              Found {{ results_count }} message in last 90 days matching <i>{{search}}</i>.
+                              -plural
+                                {{ start }} - {{ end }} of {{ results_count }} results for <i>{{search}}</i> since {{start_date}}.
+                          -else
+                            -if start_date
+                              -blocktrans trimmed with results_count=paginator.count|intcomma start=page_obj.start_index|intcomma end=page_obj.end_index|intcomma count cc=paginator.count 
+                                {{ results_count }} message since {{ start_date}}.
+                                -plural
+                                  {{ start }} - {{ end }} of {{ results_count }} messages since {{ start_date}}.
+                                    
+                      .flex-grow
+                        -include "includes/pages.html"
+        -else
+          -include "msgs/empty_include.html"
+
+-block extra-script
+  {{ block.super }}
+  :javascript
+
+    function handleRowClick(uuid) {
+      gotoLink("/contact/read/" + uuid + "/");
+    }
+
+    {% if org_perms.msgs.msg_update %}
+
+    function handleCreateLabelModalLoaded(event) {
+      lastChecked = getCheckedIds();
+      var body = event.detail.body;
+      body.querySelector("#id_messages").value = lastChecked.join();
+    }
+
+    function handleCreateLabelModalSubmitted(event) {
+      refresh(function() { recheckIds(); }, true);
+    }
+
+    function handleSendMessageClicked() {
+      var sendEndpoint = "{% url 'msgs.broadcast_send' %}";
+      var sendModal = document.querySelector("#send-message-modal");
+      var msgIds = getCheckedIds();
+      if (msgIds.length > 0) {
+        sendModal.setAttribute("endpoint", sendEndpoint + '?m=' + msgIds);
+      } else {
+        sendModal.setAttribute("endpoint", sendEndpoint);
+      }
+    }
+    {% endif %}
+
+    function handleAddLabelClicked() {
+      document.getElementById("create-label-modal").open = true;
+    }

--- a/engage/msgs/__init__.py
+++ b/engage/msgs/__init__.py
@@ -1,0 +1,11 @@
+from django.apps import AppConfig as BaseAppConfig
+
+default_app_config = 'engage.msgs.AppConfig'
+
+class AppConfig(BaseAppConfig):
+    """
+    django app labels must be unique; so override AppConfig to ensure uniqueness
+    """
+    name = "engage.msgs"
+    label = "engage_msgs"
+    verbose_name = "Engage Messages"

--- a/engage/msgs/datepicker.py
+++ b/engage/msgs/datepicker.py
@@ -1,0 +1,5 @@
+from temba import settings
+
+class DatePickerMedia:
+    js = ('{}js/bootstrap-datepicker.js'.format(settings.STATIC_URL),)
+    css = {'all': ('{}css/bootstrap-datepicker3.css'.format(settings.STATIC_URL),)}

--- a/engage/msgs/exporter.py
+++ b/engage/msgs/exporter.py
@@ -1,0 +1,123 @@
+from django.conf import settings
+from django.contrib import messages
+from django.http import HttpResponse, HttpResponseRedirect
+from django.urls import reverse
+from django.utils.http import is_safe_url, urlquote_plus
+from django.utils.safestring import mark_safe
+from django.utils.translation import ugettext_lazy as _
+
+from smartmin.views import SmartFormView
+
+from temba.orgs.views import ModalMixin, OrgPermsMixin
+from temba.utils import json, on_transaction_commit
+
+from temba.msgs.models import ExportMessagesTask, Label
+from temba.msgs.tasks import export_messages_task
+from temba.msgs.views import ExportForm
+
+class Exporter(ModalMixin, OrgPermsMixin, SmartFormView):
+    """
+    Export messages override to allow for ASYNC/SYNC behavior.
+    """
+
+    form_class = ExportForm
+    submit_button_name = "Export"
+    success_url = "@msgs.msg_inbox"
+
+    def derive_label(self):
+        # label is either a UUID of a Label instance (36 chars) or a system label type code (1 char)
+        label_id = self.request.GET["l"]
+        if len(label_id) == 1:
+            return label_id, None
+        else:
+            return None, Label.all_objects.get(org=self.request.user.get_org(), uuid=label_id)
+
+    def get_success_url(self):
+        redirect = self.request.GET.get("redirect")
+        if redirect and not is_safe_url(redirect, self.request.get_host()):
+            redirect = None
+
+        return redirect or reverse("msgs.msg_inbox")
+
+    def form_invalid(self, form):  # pragma: needs cover
+        if "_format" in self.request.GET and self.request.GET["_format"] == "json":
+            return HttpResponse(
+                json.dumps(dict(status="error", errors=form.errors)), content_type="application/json", status=400
+            )
+        else:
+            return super().form_invalid(form)
+
+    def form_valid(self, form):
+        user = self.request.user
+        org = user.get_org()
+
+        export_all = bool(int(form.cleaned_data["export_all"]))
+        groups = form.cleaned_data["groups"]
+        start_date = form.cleaned_data["start_date"]
+        end_date = form.cleaned_data["end_date"]
+
+        system_label, label = (None, None) if export_all else self.derive_label()
+
+        # is there already an export taking place?
+        existing = ExportMessagesTask.get_recent_unfinished(org)
+        if existing:
+            messages.info(
+                self.request,
+                _(
+                    "There is already an export in progress, started by %s. You must wait "
+                    "for that export to complete before starting another." % existing.created_by.username
+                ),
+            )
+
+        # otherwise, off we go
+        else:
+            export = ExportMessagesTask.create(
+                org,
+                user,
+                system_label=system_label,
+                label=label,
+                groups=groups,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+            if settings.ASYNC_MESSAGE_EXPORT:
+                on_transaction_commit(lambda: export_messages_task.delay(export.id))
+
+                if not getattr(settings, "CELERY_ALWAYS_EAGER", False):  # pragma: needs cover
+                    messages.info(
+                        self.request,
+                        _("We are preparing your export. We will e-mail you at %s when " "it is ready.")
+                        % self.request.user.email,
+                    )
+
+                else:
+                    dl_url = reverse("assets.download", kwargs=dict(type="message_export", pk=export.pk))
+                    messages.info(
+                        self.request,
+                        _("Export complete, you can find it here: %s (production users " "will get an email)")
+                        % dl_url,
+                    )
+
+            else:
+                on_transaction_commit(lambda: export_messages_task.run(export.id))
+                dl_url = reverse("assets.download", kwargs=dict(type="message_export", pk=export.pk))
+                messages.info(self.request,
+                    mark_safe(_(f"Export complete, you can find it here: <a href=\"{dl_url}\">{dl_url}</a>"))
+                )
+
+        messages.success(self.request, self.derive_success_message())
+
+        if "HTTP_X_PJAX" not in self.request.META:
+            return HttpResponseRedirect(self.get_success_url())
+        else:  # pragma: no cover
+            response = self.render_modal_response(form)
+            response["REDIRECT"] = self.get_success_url()
+            return response
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs["user"] = self.request.user
+        kwargs["label"] = self.derive_label()[1]
+        return kwargs
+

--- a/engage/msgs/inboxview.py
+++ b/engage/msgs/inboxview.py
@@ -1,0 +1,36 @@
+from temba import settings
+import temba.msgs.views
+
+OrigInboxView = temba.msgs.views.InboxView
+
+class BaseInboxView(OrigInboxView):
+    """
+    Base class for inbox views with message folders and labels listed by the side
+    """
+    def pre_process(self, request, *args, **kwargs):
+        super().pre_process(request, *args, **kwargs)
+        # give us the ability to override the pagination (super helpful in debugging)
+        if settings.DEBUG:
+            if 'r' in self.request.GET:
+                self.refresh = self.request.GET['r']
+            if 'nor' in self.request.GET:
+                self.refresh = None
+            if 'page_by' in self.request.GET:
+                self.paginate_by = self.request.GET['page_by']
+
+    def process_list(self, aList):
+        """
+        Ensure HTML in messages do not bork our display.
+        :param aList: the list of message to process.
+        :return: the processed list.
+        """
+        for theMsg in aList:
+            theText = theMsg['text']
+            theText.replace(u'\xa0', ' ').replace('&nbsp;', ' ')
+            theMsg['text'] = theText
+        return aList
+
+    def get_context_data(self, **kwargs):
+        context = super().get_context_data(**kwargs)
+        context['object_list'] = self.process_list(context['object_list'])
+        return context

--- a/engage/msgs/inboxview.py
+++ b/engage/msgs/inboxview.py
@@ -1,9 +1,7 @@
 from temba import settings
-import temba.msgs.views
+from temba.msgs.views import InboxView
 
-OrigInboxView = temba.msgs.views.InboxView
-
-class BaseInboxView(OrigInboxView):
+class BaseInboxView(InboxView):
     """
     Base class for inbox views with message folders and labels listed by the side
     """
@@ -25,9 +23,14 @@ class BaseInboxView(OrigInboxView):
         :return: the processed list.
         """
         for theMsg in aList:
-            theText = theMsg['text']
-            theText.replace(u'\xa0', ' ').replace('&nbsp;', ' ')
-            theMsg['text'] = theText
+            #import engage.utils
+            #engage.utils.var_dump(theMsg)
+            theText = theMsg.text
+            # convert non-breaking spaces to normal spaces, ads abuse long strings of them
+            theText = theText.replace(u'\xa0', ' ').replace('&nbsp;', ' ')
+            # remove 0-width non-joiner characters near spaces
+            theText = theText.replace(' '+u"\u200C", ' ').replace(' &zwnj;', ' ')
+            theMsg.text = theText
         return aList
 
     def get_context_data(self, **kwargs):

--- a/engage/utils/__init__.py
+++ b/engage/utils/__init__.py
@@ -21,9 +21,9 @@ def _var_dump( obj ):
     :return: Returns the nested thing to dump.
     """
     newobj=obj
-    if '__dict__' in dir(obj):
+    if '__dict__' in dir(obj) and not isinstance(obj, dict):
         newobj=obj.__dict__
-        if ' object at ' in str(obj) and not newobj.has_key('__type__'):
+        if ' object at ' in str(obj) and 'has_key' in newobj and not newobj.has_key('__type__'):
             newobj['__type__']=str(obj)
         for attr in newobj:
             newobj[attr] = _var_dump(newobj[attr])

--- a/engage/utils/overrides.py
+++ b/engage/utils/overrides.py
@@ -84,3 +84,15 @@ def RunEngageOverrides():
     # icons for schemes are kept in a separate class for some reason
     from temba.contacts.templatetags.contacts import URN_SCHEME_ICONS
     URN_SCHEME_ICONS.update(PM_Scheme_Icons)
+
+    # override the date picker widget with one we like better
+    import smartmin.widgets
+    from engage.msgs.datepicker import DatePickerMedia
+    smartmin.widgets.DatePickerWidget.Media = DatePickerMedia
+
+    # override the Export class with our own to handle ASYNC/SYNC exports
+    from temba.msgs.views import MsgCRUDL
+    from engage.msgs.exporter import Exporter
+    MsgCRUDL.Export = Exporter
+    # give failed msgs a resend/delete action
+    setattr(MsgCRUDL.Failed, 'actions', ["resend", "delete"])

--- a/temba/msgs/views.py
+++ b/temba/msgs/views.py
@@ -1,6 +1,5 @@
 from datetime import date, timedelta
 
-from django.utils.safestring import mark_safe
 from smartmin.views import (
     SmartCreateView,
     SmartCRUDL,
@@ -44,12 +43,6 @@ from temba.utils.views import BulkActionMixin, ComponentFormMixin
 
 from .models import INITIALIZING, QUEUED, Broadcast, ExportMessagesTask, Label, Msg, Schedule, SystemLabel
 from .tasks import export_messages_task
-
-import smartmin.widgets
-class DatePickerMedia:
-    js = ('{}js/bootstrap-datepicker.js'.format(settings.STATIC_URL),)
-    css = {'all': ('{}css/bootstrap-datepicker3.css'.format(settings.STATIC_URL),)}
-smartmin.widgets.DatePickerWidget.Media = DatePickerMedia
 
 
 class SendMessageForm(Form):
@@ -108,14 +101,6 @@ class SendMessageForm(Form):
         if org.is_flagged:
             raise ValidationError(
                 _("Sorry, your workspace is currently flagged. To enable sending messages, please contact support.")
-            )
-        if org.is_flagged:
-            raise ValidationError(
-                _("Sorry, your account is currently flagged. To enable sending messages, please contact support.")
-            )
-        if org.is_flagged:
-            raise ValidationError(
-                _("Sorry, your account is currently flagged. To enable sending messages, please contact support.")
             )
         return cleaned
 
@@ -585,31 +570,21 @@ class MsgCRUDL(SmartCRUDL):
                     end_date=end_date,
                 )
 
-                if settings.ASYNC_MESSAGE_EXPORT:
-                    on_transaction_commit(lambda: export_messages_task.delay(export.id))
+                on_transaction_commit(lambda: export_messages_task.delay(export.id))
 
-                    if not getattr(settings, "CELERY_ALWAYS_EAGER", False):  # pragma: needs cover
-                        messages.info(
-                            self.request,
-                            _("We are preparing your export. We will e-mail you at %s when " "it is ready.")
-                            % self.request.user.email,
-                        )
-
-                    else:
-                        dl_url = reverse("assets.download", kwargs=dict(type="message_export", pk=export.pk))
-                        messages.info(
-                            self.request,
-                            _("Export complete, you can find it here: %s (production users " "will get an email)")
-                            % dl_url,
-                        )
+                if not getattr(settings, "CELERY_ALWAYS_EAGER", False):  # pragma: needs cover
+                    messages.info(
+                        self.request,
+                        _("We are preparing your export. We will e-mail you at %s when " "it is ready.")
+                        % self.request.user.username,
+                    )
 
                 else:
-                    on_transaction_commit(lambda: export_messages_task.run(export.id))
                     dl_url = reverse("assets.download", kwargs=dict(type="message_export", pk=export.pk))
                     messages.info(
                         self.request,
-                        mark_safe(_("Export complete, you can find it here: <a href=\"%s\">%s</a>")
-                                  % (dl_url, dl_url))
+                        _("Export complete, you can find it here: %s (production users " "will get an email)")
+                        % dl_url,
                     )
 
             messages.success(self.request, self.derive_success_message())
@@ -703,7 +678,6 @@ class MsgCRUDL(SmartCRUDL):
         template_name = "msgs/msg_failed.haml"
         success_message = ""
         system_label = SystemLabel.TYPE_FAILED
-        actions = ["resend", "delete"]
         allow_export = True
         show_channel_logs = True
 


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Ticket for bug-that-was-not-a-bug, fixed:
Users with a single org have CSS similar to the org picker for contrast and visiblity.
Contact "Send via *" buttons now have tooltips as well as a group label.
Messages that contain HTML (email ads mostly) processed to remove problems like long strings of non-breaking spaces that will break the page being rendered too wide to view properly.

#### Release Note
Visual polish applied, no functional changes in this PR.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

*Steps to test your application for someone not familiar with it.* Required.

1. Do this: `$ run-this.sh`
2. Look for this.
3. Clean up with this command
