### PR TITLE
P4-2858: PM channel last_seen timestamp QC

### DIFF
--- a/engage/channels/tasks.py
+++ b/engage/channels/tasks.py
@@ -1,0 +1,36 @@
+import logging
+import requests
+
+from django.conf import settings
+
+from celery.task import task
+
+from temba.channels.models import Channel
+from temba.channels.types.postmaster import PostmasterType
+
+logger = logging.getLogger(__name__)
+
+@task(track_started=True, name="update_postmaster_sync_task")
+def update_postmaster_sync_task():
+    """
+    Run every 5 minutes and updates postmaster channel sync times.
+    """
+    api_url = getattr(settings, "POST_OFFICE_API_URL")
+    api_key = getattr(settings, "POST_OFFICE_API_KEY")
+    for channel in Channel.objects.filter(is_active=True, channel_type=PostmasterType.code):
+        resp = None
+        try:
+            resp = requests.get(f"{api_url}/engage/admin/device?id={channel.address}", headers={'po-api-key': api_key})
+            last_seen = resp.json()['devices'][0]['last_seen']
+            if last_seen is not None:
+                if channel.last_seen is None or channel.last_seen < last_seen:
+                    channel.last_seen = last_seen
+                    channel.save()
+        except Exception as ex:
+            logger.exception(f"{ex}", extra={
+                'url': f"{api_url}/engage/admin/device?id={channel.address}",
+                'channel_name': channel.name,
+                'channel_addr': channel.address,
+                'response_code': resp.status_code if resp else None,
+                'response_body': resp.content if resp else None,
+            })

--- a/temba/channels/tasks.py
+++ b/temba/channels/tasks.py
@@ -52,12 +52,6 @@ def send_alert_task(alert_id, resolved):
     alert = Alert.objects.get(pk=alert_id)
     alert.send_email(resolved)
 
-@nonoverlapping_task(track_started=True, name="trim_sync_events_task")
-def trim_sync_events_task():  # pragma: needs cover
-    """
-    Runs daily and clears any channel sync events that are older than 7 days
-    """
-    SyncEvent.trim()
 
 @nonoverlapping_task(track_started=True, name="trim_sync_events_task")
 def trim_sync_events_task():  # pragma: needs cover
@@ -94,22 +88,6 @@ def trim_channel_log_task():  # pragma: needs cover
 def squash_channelcounts():
     ChannelCount.squash()
 
-@task(track_started=True, name="update_postmaster_sync_task")
-def update_postmaster_sync_task():
-    """
-    Run every 5 minutes and updates postmaster channel sync times.
-    """
-    import requests
-    api_url = getattr(settings, "POST_OFFICE_API_URL")
-    api_key = getattr(settings, "POST_OFFICE_API_KEY")
-    from temba.channels.types.postmaster import PostmasterType
-    for channel in Channel.objects.filter(is_active=True, channel_type=PostmasterType.code):
-        try:
-            resp = requests.get(f"{api_url}/engage/admin/device?id={channel.address}", headers={'x-api-key': api_key})
-            channel.last_seen = resp.json()['devices'][0]['last_seen']
-            channel.save()
-        except Exception as ex:
-            logger.debug(f'{ex}: {api_url}/engage/admin/device?id={channel.address} {resp.status_code} {resp.content}')
 
 @nonoverlapping_task(
     track_started=True, name="track_org_channel_counts", lock_key="track_org_channel_counts", lock_timeout=7200


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Update PM channel last_seen timestamp with more quality control.

#### Release Note
Last Seen timestamp for PostMaster channels more reliable now.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

Celery task for updating PostMaster channel last_seen datetimes now ensure the timestamp is more recent than what is saved and log errors should any occur (was Debug level before). 