### PR TITLE
P4-3778: Download PM behind random link

### DIFF
--- a/docker/customizations/any/temba/orgs/views.py
+++ b/docker/customizations/any/temba/orgs/views.py
@@ -1811,7 +1811,7 @@ class OrgCRUDL(EngageOrgCRUDMixin, SmartCRUDL):
                 super().__init__(*args, **kwargs)
 
                 # orgs see agent role choice if they have an internal ticketing enabled
-                has_internal = org.has_internal_ticketing()
+                has_internal = org.has_internal_ticketing() if org else False
                 role_choices = [(r.code, r.display) for r in OrgRole if r != OrgRole.AGENT or has_internal]
 
                 self.fields["invite_role"].choices = role_choices

--- a/engage/channels/types/postmaster/download.py
+++ b/engage/channels/types/postmaster/download.py
@@ -48,25 +48,17 @@ class DownloadPostmasterMixin:
                 apk_content_type = 'application/vnd.android.package-archive'
                 try:
                     resp: requests.Response = requests.get(self.fetch_url, auth=self.fetch_auth)
-                    logger.debug("pm fetch url", extra=self.withLogInfo({
-                        'url': self.fetch_url,
-                        'resp': resp,
-                        'content-type': resp.headers.get('Content-Type') if resp is not None else '',
-                    }))
                     if resp is not None and resp.ok:
                         ctype = resp.headers.get('Content-Type')
                         if ctype is not None and ctype.startswith('text/html'):
                             list_of_links = resp.text
-                            logger.debug("pm fetch list", extra=self.withLogInfo({
-                                'list': list_of_links,
-                            }))
                             pm_link_match: Optional[Match[str]] = None
                             # page may list ordered links, get last one: <a href="postmaster-4.0.15.alpha.2709.apk">
                             for pm_link_match in re.finditer(r'<a href="(.+\.apk)">', list_of_links):
                                 pass
-                            logger.debug("pm link parse", extra=self.withLogInfo({
+                            logger.debug("pm link parse", extra={
                                 'pm_link': pm_link_match.group(1) if pm_link_match else None,
-                            }))
+                            })
                             if pm_link_match:
                                 pm_filename = pm_link_match.group(1)
                                 if self.fetch_url.endswith('/'):
@@ -88,18 +80,18 @@ class DownloadPostmasterMixin:
                             return r
                         #endif
                     #endif
-                    logger.error("pm fetch url failed to fetch apk", extra=self.withLogInfo({
+                    logger.error("pm fetch url failed to fetch apk", extra={
                         'url': self.fetch_url,
                         'resp': resp,
                         'content-type': resp.headers.get('Content-Type') if resp is not None else '',
-                    }))
+                    })
                     return HttpResponse('file not found', status=404)
                 except ValueError as vx:
                     return HttpResponse(vx, status=500)
                 #endtry
             else:
-                logger.warning("POST_MASTER_FETCH_URL not defined", extra=self.withLogInfo({
-                }))
+                logger.warning("POST_MASTER_FETCH_URL not defined", extra={
+                })
                 raise ValueError("file not found.")
             #endif
         #enddef get

--- a/engage/hamls/orgs/email/invitation_email.html
+++ b/engage/hamls/orgs/email/invitation_email.html
@@ -1,0 +1,18 @@
+{% extends "email_base.html" %}
+
+{% load tz %}
+{% load i18n %}
+{% block body %}
+
+<p>
+  {% blocktrans with org=org.name link=branding.link brand=branding.name secret=invitation.secret %}
+      You've been invited to join {{ brand }} as a member of {{ org }}.
+      <br/>
+      To accept the invitation, click the following link: <br/>
+      <br/>
+      https://{{link}}/org/join/{{secret}}/
+      <br/>
+  {% endblocktrans %}
+</p>
+
+{% endblock body %}

--- a/engage/utils/overrides.py
+++ b/engage/utils/overrides.py
@@ -4,8 +4,13 @@ the form of methods put into specific classes "after initialization, but before 
 
 Import this file just after all the urls in the main urls.py and run its overrides.
 """
+import logging
+
 from django.conf import settings
+from django.urls import reverse
 from django.utils.translation import ugettext_lazy as _
+
+from engage.utils.strings import is_empty
 
 def _TrackUser(self):  # pragma: no cover
     """
@@ -21,6 +26,9 @@ def RunEngageOverrides():
     """
     Overrides that need to be conducted at the tail end of temba/urls.py
     """
+    if getattr(settings, "ENGAGE_OVERRIDES_RAN", False):
+        return
+
     from django.contrib.auth.models import AnonymousUser, User
     User.track_user = _TrackUser
     User.using_token = False  # default optional property to False so it exists.
@@ -114,3 +122,5 @@ def RunEngageOverrides():
     from temba.contacts.templatetags.contacts import register
     from engage.contacts.templatetags import scheme_icon
     register.filter(scheme_icon)
+
+    settings.ENGAGE_OVERRIDES_RAN = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -67,6 +67,8 @@ amqp = "2.6.1"
 dicttoxml = "1.7.4"
 django-getenv = "1.3.1"
 django-cache-url = "1.3.1"
+pypng = "^0.20220715.0"
+pyqrcode = "^1.2"
 uwsgi = "2.0.18"
 whitenoise = "^5.1"
 #----- oidc _PROVIDER_

--- a/temba/api/models.py
+++ b/temba/api/models.py
@@ -48,6 +48,9 @@ class APIPermission(BasePermission):
             else:
                 return False
 
+            if not role_group:
+                return False
+
             codename = view.permission.split(".")[-1]
             has_perm = role_group.permissions.filter(codename=codename).exists()
 

--- a/temba/channels/types/postmaster/postoffice.py
+++ b/temba/channels/types/postmaster/postoffice.py
@@ -20,6 +20,7 @@ def fetch_qr_code(org):
             data=data,
             cookies=None,
             verify=False,
+            timeout=10,
         )
         if r.status_code == 200:
             return json.loads(r.content)["data"]

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -104,7 +104,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
             self.pm_app_url = request.build_absolute_uri(reverse('channels.channel_download_postmaster'))
             qrc = pyqrcode.create(self.pm_app_url)
             qrstream = io.BytesIO()
-            qrc.png(qrstream, scale=6)
+            qrc.png(qrstream, scale=4)
             self.pm_app_qrcode = f"data:image/png;base64, {base64.b64encode(qrstream.getvalue()).decode('ascii')}"
         #endif
     #enddef init_pm_app_dl

--- a/temba/channels/types/postmaster/views.py
+++ b/temba/channels/types/postmaster/views.py
@@ -1,3 +1,6 @@
+import base64
+import io
+import pyqrcode
 from uuid import uuid4
 
 from django import forms
@@ -21,13 +24,15 @@ from ...views import (
     ClaimViewMixin,
 )
 
+from engage.utils.strings import is_empty
+
 
 class ClaimView(BaseClaimNumberMixin, SmartFormView):
     code = "PSM"
     uuid = None
     extra_links = None
-    pm_app_url = getattr(settings, "POST_MASTER_DL_URL", ())
-    pm_app_qrcode = getattr(settings, "POST_MASTER_DL_QRCODE", ())
+    pm_app_url: str = getattr(settings, "POST_MASTER_DL_URL", '')
+    pm_app_qrcode: str = getattr(settings, "POST_MASTER_DL_QRCODE", '')
 
     class Form(ClaimViewMixin.Form):
         CHAT_MODE_CHOICES = getattr(settings, "CHAT_MODE_CHOICES", ())
@@ -39,7 +44,6 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         org_id = forms.IntegerField(label="Org ID", help_text=_("Org ID"))
 
         def clean(self):
-
             device_name = self.cleaned_data.get("device_name", None)
             device_id = self.cleaned_data.get("device_id", None)
             chat_mode = self.cleaned_data.get("chat_mode", None)
@@ -95,6 +99,16 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
     def get_claim_url(self):
         return reverse("channels.types.postmaster.claim")
 
+    def init_pm_app_dl(self, request):
+        if is_empty(self.pm_app_url) and not is_empty(settings.POST_MASTER_FETCH_URL):
+            self.pm_app_url = request.build_absolute_uri(reverse('channels.channel_download_postmaster'))
+            qrc = pyqrcode.create(self.pm_app_url)
+            qrstream = io.BytesIO()
+            qrc.png(qrstream, scale=6)
+            self.pm_app_qrcode = f"data:image/png;base64, {base64.b64encode(qrstream.getvalue()).decode('ascii')}"
+        #endif
+    #enddef init_pm_app_dl
+
     def get_gear_links(self):
         links = []
 
@@ -117,6 +131,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
         context['po_qr'] = postoffice.fetch_qr_code(self.org)
+        self.init_pm_app_dl(self.request)
         context['pm_app_url'] = self.pm_app_url
         context['pm_app_qrcode'] = self.pm_app_qrcode
         return context
@@ -169,7 +184,7 @@ class ClaimView(BaseClaimNumberMixin, SmartFormView):
         scheme_to_check = '{}{}_SCHEME'.format(prefix, dict(ClaimView.Form.CHAT_MODE_CHOICES)[chat_mode]).upper()
 
         schemes = [getattr(Contacts.URN, scheme_to_check)]
-        
+
         name_with_scheme = '{} [{}]'.format(device_name, schemes[0])
 
         channel = Channel.create(

--- a/temba/settings_engage.py
+++ b/temba/settings_engage.py
@@ -9,6 +9,7 @@ from getenv import env
 from glob import glob
 import dj_database_url
 import django_cache_url
+import uuid
 
 from engage.auth.oauth_config import OAuthConfig
 from engage.utils.strings import is_empty, str2bool
@@ -413,6 +414,8 @@ DEFAULT_BRAND_OBJ.update({
 POST_MASTER_FETCH_URL = env('POST_MASTER_FETCH_URL', None)
 POST_MASTER_FETCH_USER = env('POST_MASTER_FETCH_USER', None)
 POST_MASTER_FETCH_PSWD = env('POST_MASTER_FETCH_PSWD', None)
+# low-effort, easily changed, endpoint obfuscation
+POST_MASTER_DL_URL_NONCE = uuid.uuid4().hex  #.hex removes the dashes
 
 MSG_FIELD_SIZE = env('MSG_FIELD_SIZE', 4096)
 


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
If the old DL PM env vars are blank (for link and QRCode base64 definition) and the new Fetch PM vars are set, generate a random dl_pm url link and create the QRCode for it.

#### Release Note
Download PM link randomly generated on container start.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

Download PM endpoint is now randomly generated on container start rather than be fixed and publicly available.

ALSO: Email invites use raw URL instead of an <a> HTML tag.
