### PR TITLE
P4-4131: missing Send Msg confirmation box

### DIFF
--- a/engage/archives/models.py
+++ b/engage/archives/models.py
@@ -8,6 +8,10 @@ from temba.archives.models import Archive
 class ArchiveOverrides(ClassOverrideMixinMustBeFirst, Archive):
     override_ignore = ignoreDjangoModelAttrs(Archive)
 
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
+
     @classmethod
     def s3_client(cls):
         # use same code as the currently working api/v2 s3 downloads

--- a/engage/channels/models.py
+++ b/engage/channels/models.py
@@ -7,6 +7,10 @@ from temba.contacts.models import URN
 class ChannelOverrides(ClassOverrideMixinMustBeFirst, Channel):
     override_ignore = ignoreDjangoModelAttrs(Channel)
 
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
+
     @classmethod
     def create(
             cls,
@@ -32,6 +36,7 @@ class ChannelOverrides(ClassOverrideMixinMustBeFirst, Channel):
     #enddef create
 
 #endclass ChannelOverrides
+
 
 from temba.channels.types.android.type import AndroidType
 class AndroidTypeOverrides(ClassOverrideMixinMustBeFirst, AndroidType):

--- a/engage/contacts/models.py
+++ b/engage/contacts/models.py
@@ -2,8 +2,13 @@ from engage.utils.class_overrides import ClassOverrideMixinMustBeFirst, ignoreDj
 
 from temba.contacts.models import ContactField
 
+
 class ContactFieldOverrides(ClassOverrideMixinMustBeFirst, ContactField):
     override_ignore = ignoreDjangoModelAttrs(ContactField)
+
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
 
     @classmethod
     def get_or_create(cls, org, user, key, label=None, show_in_table=None, value_type=None, priority=None):

--- a/engage/msgs/models.py
+++ b/engage/msgs/models.py
@@ -9,6 +9,10 @@ from temba.msgs.models import Msg, Label
 class MsgModelOverride(ClassOverrideMixinMustBeFirst, Msg):
     override_ignore = ignoreDjangoModelAttrs(Msg)
 
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
+
     def archive(self):
         """
         Archives this message
@@ -35,8 +39,13 @@ class MsgModelOverride(ClassOverrideMixinMustBeFirst, Msg):
 
 #endclass MsgModelOverride
 
+
 class LabelModelOverride(ClassOverrideMixinMustBeFirst, Label):
     override_ignore = ignoreDjangoModelAttrs(Label)
+
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
 
     #MAX_ORG_LABELS = 250
     # remove hard-coded limit in favor of settings-based max limit

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -1,6 +1,9 @@
 $(document).ready(function() {
     let rootSelectorName = "#send-message";
-    if ( $(document.querySelector('temba-modax')
+    if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
+        rootSelectorName = "#send-message-modal";
+    }
+    else if ( $(document.querySelector("temba-modax")
         .shadowRoot.querySelector("temba-dialog")
         .shadowRoot.querySelector(".dialog-footer")
         .querySelector("temba-button[primary]"))[0] !== undefined )

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -1,6 +1,9 @@
 $(document).ready(function() {
-    let rootSelectorName = "#send-message";
-    if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
+    let rootSelectorName = "#send-msg";
+    if ( $(document.querySelector("#send-message") ) !== undefined ) {
+        rootSelectorName = "#send-message";
+    }
+    else if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
         rootSelectorName = "#send-message-modal";
     }
     else if ( $(document.querySelector("temba-modax")

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -11,13 +11,18 @@ $(document).ready(function() {
         rootSelectorName = "temba-modax";
     }
 
-    let selector = $(document.querySelector(rootSelectorName)
-        .shadowRoot.querySelector("temba-dialog")
-        .shadowRoot.querySelector(".dialog-footer")
-        .querySelector("temba-button[primary]")
-        .shadowRoot.querySelector("div")
-    );
-    if (selector) {
+    let selector;
+    try {
+        selector = $(document.querySelector(rootSelectorName)
+            .shadowRoot.querySelector("temba-dialog")
+            .shadowRoot.querySelector(".dialog-footer")
+            .querySelector("temba-button[primary]")
+            .shadowRoot.querySelector("div")
+        );
+    } catch (e) {
+        selector = null;
+    }
+    if ( selector ) {
         let bIsAskingUser = false; //code might take a brief moment, prevent mutli-click-dialogs
         $(selector).on("click", function (e) {
             let bUserChoseOK = false;

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -25,8 +25,8 @@ $(document).ready(function() {
     if ( selector ) {
         let bIsAskingUser = false; //code might take a brief moment, prevent mutli-click-dialogs
         $(selector).on("click", function (e) {
-            let bUserChoseOK = undefined;
-            if ( !bIsAskingUser && bUserChoseOK === undefined ) {
+            let bUserChoseOK = false;
+            if ( !bIsAskingUser ) {
                 bIsAskingUser = true;
 
                 let theText = $(document.querySelector(rootSelectorName)
@@ -48,12 +48,12 @@ $(document).ready(function() {
                 });
 
                 bUserChoseOK = confirm(`Are you sure you want to send the message:\n${theText}\n\nto ${theRecipients.join(', ')}?`);
-                bIsAskingUser = false;
             }
             if ( !bUserChoseOK ) {
                 e.preventDefault();
                 e.stopPropagation();
             }
+            bIsAskingUser = false;
         });
     }
 });

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     let rootSelectorName = "#send-message";
     if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
-        rootSelectorName = "#send-message-modal";
+        rootSelectorName = "skip-already-handled";
     }
     else if ( $(document.querySelector("temba-modax")
         .shadowRoot.querySelector("temba-dialog")

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     let rootSelectorName = "#send-message";
     if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
-        rootSelectorName = "skip-already-handled";
+        rootSelectorName = "#send-message-modal";
     }
     else if ( $(document.querySelector("temba-modax")
         .shadowRoot.querySelector("temba-dialog")
@@ -25,8 +25,8 @@ $(document).ready(function() {
     if ( selector ) {
         let bIsAskingUser = false; //code might take a brief moment, prevent mutli-click-dialogs
         $(selector).on("click", function (e) {
-            let bUserChoseOK = false;
-            if ( !bIsAskingUser ) {
+            let bUserChoseOK = undefined;
+            if ( !bIsAskingUser && bUserChoseOK === undefined ) {
                 bIsAskingUser = true;
 
                 let theText = $(document.querySelector(rootSelectorName)

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -22,9 +22,9 @@ $(document).ready(function() {
     } catch (e) {
         selector = null;
     }
-    if ( selector ) {
+    if ( selector && !selector.hasClass("confirm-click-handler") ) {
         let bIsAskingUser = false; //code might take a brief moment, prevent mutli-click-dialogs
-        $(selector).on("click", function (e) {
+        $(selector).addClass("confirm-click-handler").on("click", function (e) {
             let bUserChoseOK = false;
             if ( !bIsAskingUser ) {
                 bIsAskingUser = true;
@@ -48,12 +48,12 @@ $(document).ready(function() {
                 });
 
                 bUserChoseOK = confirm(`Are you sure you want to send the message:\n${theText}\n\nto ${theRecipients.join(', ')}?`);
+                bIsAskingUser = false;
             }
             if ( !bUserChoseOK ) {
                 e.preventDefault();
                 e.stopPropagation();
             }
-            bIsAskingUser = false;
         });
     }
 });


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Contact list selection Send Message did not have a confirmation dialog.

#### Release Note
Contact list selection Send Message did not have a confirmation dialog.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

Send Messages buttons in:
Messages page
Contact page
Contact List page, when message checked

in all areas, send a message and Cancel/Send to ensure a confirmation dialog shows up and both options work as expected.