### PR TITLE
P4-4185: Failed Msg inbox get 500 error

### DIFF
--- a/engage/archives/models.py
+++ b/engage/archives/models.py
@@ -8,6 +8,10 @@ from temba.archives.models import Archive
 class ArchiveOverrides(ClassOverrideMixinMustBeFirst, Archive):
     override_ignore = ignoreDjangoModelAttrs(Archive)
 
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
+
     @classmethod
     def s3_client(cls):
         # use same code as the currently working api/v2 s3 downloads

--- a/engage/channels/models.py
+++ b/engage/channels/models.py
@@ -7,6 +7,10 @@ from temba.contacts.models import URN
 class ChannelOverrides(ClassOverrideMixinMustBeFirst, Channel):
     override_ignore = ignoreDjangoModelAttrs(Channel)
 
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
+
     @classmethod
     def create(
             cls,
@@ -32,6 +36,7 @@ class ChannelOverrides(ClassOverrideMixinMustBeFirst, Channel):
     #enddef create
 
 #endclass ChannelOverrides
+
 
 from temba.channels.types.android.type import AndroidType
 class AndroidTypeOverrides(ClassOverrideMixinMustBeFirst, AndroidType):

--- a/engage/channels/views.py
+++ b/engage/channels/views.py
@@ -16,8 +16,8 @@ class ChannelCRUDLOverrides(ClassOverrideMixinMustBeFirst, ManageChannelMixin,
     override_ignore = ('get_actions',)
 
     @staticmethod
-    def on_apply_overrides():
-        ChannelCRUDL.actions += \
+    def on_apply_overrides(under_cls):
+        under_cls.actions += \
            ManageChannelMixin.get_actions() + \
            PurgeOutboxMixin.get_actions() + \
            APIsForDownloadPostmaster.get_actions()

--- a/engage/contacts/models.py
+++ b/engage/contacts/models.py
@@ -2,8 +2,13 @@ from engage.utils.class_overrides import ClassOverrideMixinMustBeFirst, ignoreDj
 
 from temba.contacts.models import ContactField
 
+
 class ContactFieldOverrides(ClassOverrideMixinMustBeFirst, ContactField):
     override_ignore = ignoreDjangoModelAttrs(ContactField)
+
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
 
     @classmethod
     def get_or_create(cls, org, user, key, label=None, show_in_table=None, value_type=None, priority=None):

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -13,7 +13,9 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     #enddef get_bulk_actions
 
     def get_context_data(self, **kwargs):
-        print(self.myClassType + "child of " + super(self.myClassType))
+        import logging
+        logger = logging.getLogger(__name__)
+        logger.debug(self.myClassType + "child of " + super(self.myClassType))
         context = super(self.myClassType).get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -26,17 +26,17 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     #     return context
     # #enddef get_context_data
 
-    @classmethod
-    def on_apply_overrides(cls) -> None:
-        # child class wonky super() makes this workaround necessary
-        setattr(cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
-        logger.debug(f"override: set attr {str(cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
-    #enddef on_apply_overrides
-
-    def get_context_data(self, **kwargs):
-        context = self.get_orig_context_data(**kwargs)
-        context['object_list'] = self._sanitizeMsgList(context['object_list'])
-        return context
-    #enddef get_context_data
+    # @staticmethod
+    # def on_apply_overrides(under_cls) -> None:
+    #     # child class wonky super() makes this workaround necessary
+    #     setattr(under_cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
+    #     logger.debug(f"override: set attr {str(under_cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
+    # #enddef on_apply_overrides
+    #
+    # def get_context_data(self, **kwargs):
+    #     context = self.get_orig_context_data(**kwargs)
+    #     context['object_list'] = self._sanitizeMsgList(context['object_list'])
+    #     return context
+    # #enddef get_context_data
 
 #endclass ViewInboxFailedMsgsOverrides

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -15,8 +15,8 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     def get_context_data(self, **kwargs):
         import logging
         logger = logging.getLogger(__name__)
-        logger.debug(str(self.myClassType) + "child of " + str(super(self.myClassType)))
-        context = super(self.myClassType).get_context_data(**kwargs)
+        logger.debug(str(self.myClassType) + "child of " + str(super(self.myClassType, self)))
+        context = super(self.myClassType, self).get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context
     #enddef get_context_data

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -12,4 +12,10 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
         return self.bulk_actions
     #enddef get_bulk_actions
 
+    def get_context_data(self, **kwargs):
+        context = super(self.myClassType).origattrs.get('get_context_data')(self, **kwargs)
+        context['object_list'] = self._sanitizeMsgList(context['object_list'])
+        return context
+    #enddef get_context_data
+
 #endclass ViewInboxFailedMsgsOverrides

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -1,6 +1,6 @@
 from engage.utils.class_overrides import ClassOverrideMixinMustBeFirst
 
-from temba.msgs.views import MsgCRUDL
+from temba.msgs.views import MsgCRUDL, InboxView
 
 class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Failed):
     """
@@ -12,13 +12,13 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
         return self.bulk_actions
     #enddef get_bulk_actions
 
-    def get_context_data(self, **kwargs):
-        import logging
-        logger = logging.getLogger(__name__)
-        logger.debug(str(MsgCRUDL.Failed) + "child of " + str(super(MsgCRUDL.Failed, self)))
-        context = super(MsgCRUDL.Failed, self).get_context_data(**kwargs)
-        context['object_list'] = self._sanitizeMsgList(context['object_list'])
-        return context
-    #enddef get_context_data
+    # def get_context_data(self, **kwargs):
+    #     import logging
+    #     logger = logging.getLogger(__name__)
+    #     logger.debug(str(MsgCRUDL.Failed) + "child of " + str(super(InboxView, self)))
+    #     context = super(InboxView, self).get_context_data(**kwargs)
+    #     context['object_list'] = self._sanitizeMsgList(context['object_list'])
+    #     return context
+    # #enddef get_context_data
 
 #endclass ViewInboxFailedMsgsOverrides

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -15,7 +15,7 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     def get_context_data(self, **kwargs):
         import logging
         logger = logging.getLogger(__name__)
-        logger.debug(self.myClassType + "child of " + super(self.myClassType))
+        logger.debug(str(self.myClassType) + "child of " + str(super(self.myClassType)))
         context = super(self.myClassType).get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -1,6 +1,11 @@
+import logging
+
 from engage.utils.class_overrides import ClassOverrideMixinMustBeFirst
 
 from temba.msgs.views import MsgCRUDL, InboxView
+
+
+logger = logging.getLogger(__name__)
 
 class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Failed):
     """
@@ -20,5 +25,18 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     #     context['object_list'] = self._sanitizeMsgList(context['object_list'])
     #     return context
     # #enddef get_context_data
+
+    @classmethod
+    def on_apply_overrides(cls) -> None:
+        # child class wonky super() makes this workaround necessary
+        setattr(cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
+        logger.debug(f"override: set attr {str(cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
+    #enddef on_apply_overrides
+
+    def get_context_data(self, **kwargs):
+        context = self.get_orig_context_data(**kwargs)
+        context['object_list'] = self._sanitizeMsgList(context['object_list'])
+        return context
+    #enddef get_context_data
 
 #endclass ViewInboxFailedMsgsOverrides

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -15,8 +15,8 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     def get_context_data(self, **kwargs):
         import logging
         logger = logging.getLogger(__name__)
-        logger.debug(str(self.myClassType) + "child of " + str(super(self.myClassType, self)))
-        context = super(self.myClassType, self).get_context_data(**kwargs)
+        logger.debug(str(MsgCRUDL.Failed) + "child of " + str(super(MsgCRUDL.Failed, self)))
+        context = super(MsgCRUDL.Failed, self).get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context
     #enddef get_context_data

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -13,6 +13,7 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     #enddef get_bulk_actions
 
     def get_context_data(self, **kwargs):
+        print(self.myClassType + "child of " + super(self.myClassType))
         context = super(self.myClassType).get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -1,11 +1,11 @@
-import logging
+#import logging
 
 from engage.utils.class_overrides import ClassOverrideMixinMustBeFirst
 
-from temba.msgs.views import MsgCRUDL, InboxView
+from temba.msgs.views import MsgCRUDL
 
 
-logger = logging.getLogger(__name__)
+#logger = logging.getLogger(__name__)
 
 class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Failed):
     """
@@ -16,27 +16,5 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     def get_bulk_actions(self):
         return self.bulk_actions
     #enddef get_bulk_actions
-
-    # def get_context_data(self, **kwargs):
-    #     import logging
-    #     logger = logging.getLogger(__name__)
-    #     logger.debug(str(MsgCRUDL.Failed) + "child of " + str(super(InboxView, self)))
-    #     context = super(InboxView, self).get_context_data(**kwargs)
-    #     context['object_list'] = self._sanitizeMsgList(context['object_list'])
-    #     return context
-    # #enddef get_context_data
-
-    # @staticmethod
-    # def on_apply_overrides(under_cls) -> None:
-    #     # child class wonky super() makes this workaround necessary
-    #     setattr(under_cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
-    #     logger.debug(f"override: set attr {str(under_cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
-    # #enddef on_apply_overrides
-    #
-    # def get_context_data(self, **kwargs):
-    #     context = self.get_orig_context_data(**kwargs)
-    #     context['object_list'] = self._sanitizeMsgList(context['object_list'])
-    #     return context
-    # #enddef get_context_data
 
 #endclass ViewInboxFailedMsgsOverrides

--- a/engage/msgs/inbox_msgfailed.py
+++ b/engage/msgs/inbox_msgfailed.py
@@ -13,7 +13,7 @@ class ViewInboxFailedMsgsOverrides(ClassOverrideMixinMustBeFirst, MsgCRUDL.Faile
     #enddef get_bulk_actions
 
     def get_context_data(self, **kwargs):
-        context = super(self.myClassType).origattrs.get('get_context_data')(self, **kwargs)
+        context = super(self.myClassType).get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context
     #enddef get_context_data

--- a/engage/msgs/models.py
+++ b/engage/msgs/models.py
@@ -9,6 +9,10 @@ from temba.msgs.models import Msg, Label
 class MsgModelOverride(ClassOverrideMixinMustBeFirst, Msg):
     override_ignore = ignoreDjangoModelAttrs(Msg)
 
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
+
     def archive(self):
         """
         Archives this message
@@ -35,8 +39,13 @@ class MsgModelOverride(ClassOverrideMixinMustBeFirst, Msg):
 
 #endclass MsgModelOverride
 
+
 class LabelModelOverride(ClassOverrideMixinMustBeFirst, Label):
     override_ignore = ignoreDjangoModelAttrs(Label)
+
+    # we do not want Django to perform any magic inheritance
+    class Meta:
+        abstract = True
 
     #MAX_ORG_LABELS = 250
     # remove hard-coded limit in favor of settings-based max limit

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -53,6 +53,7 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
     def on_apply_overrides(cls) -> None:
         # child class wonky super() makes this workaround necessary
         setattr(cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
+        logger.debug(f"override: set attr {str(cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
     #enddef on_apply_overrides
 
     def get_context_data(self, **kwargs):

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -50,7 +50,8 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
     #enddef _sanitizeMsgList
 
     def get_context_data(self, **kwargs):
-        context = self.getOrigClsAttr('get_context_data')(self, **kwargs)
+        context = self.getOrigClsAttr('get_context_data')(self, **kwargs) \
+                if self.getOrigClsAttr('get_context_data') else super().get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context
     #enddef get_context_data

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -49,11 +49,11 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
         return aList
     #enddef _sanitizeMsgList
 
-    @classmethod
-    def on_apply_overrides(cls) -> None:
+    @staticmethod
+    def on_apply_overrides(under_cls) -> None:
         # child class wonky super() makes this workaround necessary
-        setattr(cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
-        logger.debug(f"override: set attr {str(cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
+        setattr(under_cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
+        logger.debug(f"override: set attr {str(under_cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
     #enddef on_apply_overrides
 
     def get_context_data(self, **kwargs):

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -49,7 +49,7 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
         return aList
     #enddef _sanitizeMsgList
 
-    @staticmethod
+    @classmethod
     def on_apply_overrides(cls) -> None:
         # child class wonky super() makes this workaround necessary
         setattr(cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -52,7 +52,7 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
     @staticmethod
     def on_apply_overrides(under_cls) -> None:
         # child class wonky super() makes this workaround necessary
-        setattr(under_cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
+        setattr(under_cls, 'get_orig_context_data', under_cls.getOrigClsAttr('get_context_data'))
         logger.debug(f"override: set attr {str(under_cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
     #enddef on_apply_overrides
 

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -50,8 +50,7 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
     #enddef _sanitizeMsgList
 
     def get_context_data(self, **kwargs):
-        context = self.getOrigClsAttr('get_context_data')(self, **kwargs) \
-                if self.getOrigClsAttr('get_context_data') else super(self.myClassType).get_context_data(**kwargs)
+        context = self.getOrigClsAttr('get_context_data')(self, **kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context
     #enddef get_context_data

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -49,8 +49,14 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
         return aList
     #enddef _sanitizeMsgList
 
+    @staticmethod
+    def on_apply_overrides(cls) -> None:
+        # child class wonky super() makes this workaround necessary
+        setattr(cls, 'get_orig_context_data', getattr(InboxView, 'get_context_data'))
+    #enddef on_apply_overrides
+
     def get_context_data(self, **kwargs):
-        context = self.getOrigClsAttr('get_context_data')(self, **kwargs)
+        context = self.get_orig_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context
     #enddef get_context_data

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -51,7 +51,7 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
 
     def get_context_data(self, **kwargs):
         context = self.getOrigClsAttr('get_context_data')(self, **kwargs) \
-                if self.getOrigClsAttr('get_context_data') else super().get_context_data(**kwargs)
+                if self.getOrigClsAttr('get_context_data') else super(self.myClassType).get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context
     #enddef get_context_data

--- a/engage/msgs/views/inbox.py
+++ b/engage/msgs/views/inbox.py
@@ -51,19 +51,18 @@ class MsgInboxViewOverrides(ClassOverrideMixinMustBeFirst, InboxView):
 
     @staticmethod
     def on_apply_overrides(under_cls) -> None:
-        # child class wonky super() makes this workaround necessary
-        setattr(under_cls, 'get_orig_context_data', under_cls.getOrigClsAttr('get_context_data'))
-        logger.debug(f"override: set attr {str(under_cls)}.{'get_orig_context_data'} to {getattr(InboxView, 'get_context_data')}")
+        ClassOverrideMixinMustBeFirst.setOrigMethod(under_cls, 'get_context_data')
+        ClassOverrideMixinMustBeFirst.setOrigMethod(under_cls, 'get_gear_links')
     #enddef on_apply_overrides
 
     def get_context_data(self, **kwargs):
-        context = self.get_orig_context_data(**kwargs)
+        context = self.orig_get_context_data(**kwargs)
         context['object_list'] = self._sanitizeMsgList(context['object_list'])
         return context
     #enddef get_context_data
 
     def get_gear_links(self):
-        links = self.getOrigClsAttr('get_gear_links')(self)
+        links = self.orig_get_gear_links()
         links.append(
             dict(
                 title="Get PM",

--- a/engage/orgs/views/bandwidth.py
+++ b/engage/orgs/views/bandwidth.py
@@ -32,8 +32,8 @@ from temba.orgs.views import (
 class BandwidthChannelViewsMixin(ClassOverrideMixinMustBeFirst, OrgCRUDL):
 
     @staticmethod
-    def on_apply_overrides() -> None:
-        OrgCRUDL.actions += (
+    def on_apply_overrides(under_cls) -> None:
+        under_cls.actions += (
             "bandwidth_connect",
             "bandwidth_international_connect",
             "bandwidth_account",

--- a/engage/orgs/views/create.py
+++ b/engage/orgs/views/create.py
@@ -90,8 +90,8 @@ class OrgCreateForm(forms.ModelForm):
 class OrgViewCreateOverride(ClassOverrideMixinMustBeFirst, OrgCRUDL):
 
     @staticmethod
-    def on_apply_overrides() -> None:
-        OrgCRUDL.actions += ('create',)
+    def on_apply_overrides(under_cls) -> None:
+        under_cls.actions += ('create',)
     #enddef on_apply_overrides
 
     class Create(SmartCreateView):

--- a/engage/orgs/views/user_assign.py
+++ b/engage/orgs/views/user_assign.py
@@ -24,8 +24,8 @@ logger = logging.getLogger(__name__)
 class OrgViewAssignUserMixin(ClassOverrideMixinMustBeFirst, OrgCRUDL):
 
     @staticmethod
-    def on_apply_overrides() -> None:
-        OrgCRUDL.actions += ('assign_user',)
+    def on_apply_overrides(under_cls) -> None:
+        under_cls.actions += ('assign_user',)
     #enddef on_apply_overrides
 
     class AssignUser(OrgPermLogInfoMixin, OrgPermsMixin, SmartFormView):

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -1,6 +1,9 @@
 $(document).ready(function() {
     let rootSelectorName = "#send-message";
-    if ( $(document.querySelector('temba-modax')
+    if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
+        rootSelectorName = "#send-message-modal";
+    }
+    else if ( $(document.querySelector("temba-modax")
         .shadowRoot.querySelector("temba-dialog")
         .shadowRoot.querySelector(".dialog-footer")
         .querySelector("temba-button[primary]"))[0] !== undefined )

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -1,6 +1,9 @@
 $(document).ready(function() {
-    let rootSelectorName = "#send-message";
-    if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
+    let rootSelectorName = "#send-msg";
+    if ( $(document.querySelector("#send-message") ) !== undefined ) {
+        rootSelectorName = "#send-message";
+    }
+    else if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
         rootSelectorName = "#send-message-modal";
     }
     else if ( $(document.querySelector("temba-modax")

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -11,13 +11,18 @@ $(document).ready(function() {
         rootSelectorName = "temba-modax";
     }
 
-    let selector = $(document.querySelector(rootSelectorName)
-        .shadowRoot.querySelector("temba-dialog")
-        .shadowRoot.querySelector(".dialog-footer")
-        .querySelector("temba-button[primary]")
-        .shadowRoot.querySelector("div")
-    );
-    if (selector) {
+    let selector;
+    try {
+        selector = $(document.querySelector(rootSelectorName)
+            .shadowRoot.querySelector("temba-dialog")
+            .shadowRoot.querySelector(".dialog-footer")
+            .querySelector("temba-button[primary]")
+            .shadowRoot.querySelector("div")
+        );
+    } catch (e) {
+        selector = null;
+    }
+    if ( selector ) {
         let bIsAskingUser = false; //code might take a brief moment, prevent mutli-click-dialogs
         $(selector).on("click", function (e) {
             let bUserChoseOK = false;

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -25,8 +25,8 @@ $(document).ready(function() {
     if ( selector ) {
         let bIsAskingUser = false; //code might take a brief moment, prevent mutli-click-dialogs
         $(selector).on("click", function (e) {
-            let bUserChoseOK = undefined;
-            if ( !bIsAskingUser && bUserChoseOK === undefined ) {
+            let bUserChoseOK = false;
+            if ( !bIsAskingUser ) {
                 bIsAskingUser = true;
 
                 let theText = $(document.querySelector(rootSelectorName)
@@ -48,12 +48,12 @@ $(document).ready(function() {
                 });
 
                 bUserChoseOK = confirm(`Are you sure you want to send the message:\n${theText}\n\nto ${theRecipients.join(', ')}?`);
-                bIsAskingUser = false;
             }
             if ( !bUserChoseOK ) {
                 e.preventDefault();
                 e.stopPropagation();
             }
+            bIsAskingUser = false;
         });
     }
 });

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     let rootSelectorName = "#send-message";
     if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
-        rootSelectorName = "#send-message-modal";
+        rootSelectorName = "skip-already-handled";
     }
     else if ( $(document.querySelector("temba-modax")
         .shadowRoot.querySelector("temba-dialog")

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -1,7 +1,7 @@
 $(document).ready(function() {
     let rootSelectorName = "#send-message";
     if ( $(document.querySelector("#send-message-modal") ) !== undefined ) {
-        rootSelectorName = "skip-already-handled";
+        rootSelectorName = "#send-message-modal";
     }
     else if ( $(document.querySelector("temba-modax")
         .shadowRoot.querySelector("temba-dialog")
@@ -25,8 +25,8 @@ $(document).ready(function() {
     if ( selector ) {
         let bIsAskingUser = false; //code might take a brief moment, prevent mutli-click-dialogs
         $(selector).on("click", function (e) {
-            let bUserChoseOK = false;
-            if ( !bIsAskingUser ) {
+            let bUserChoseOK = undefined;
+            if ( !bIsAskingUser && bUserChoseOK === undefined ) {
                 bIsAskingUser = true;
 
                 let theText = $(document.querySelector(rootSelectorName)

--- a/engage/static/engage/js/broadcast_send.js
+++ b/engage/static/engage/js/broadcast_send.js
@@ -22,9 +22,9 @@ $(document).ready(function() {
     } catch (e) {
         selector = null;
     }
-    if ( selector ) {
+    if ( selector && !selector.hasClass("confirm-click-handler") ) {
         let bIsAskingUser = false; //code might take a brief moment, prevent mutli-click-dialogs
-        $(selector).on("click", function (e) {
+        $(selector).addClass("confirm-click-handler").on("click", function (e) {
             let bUserChoseOK = false;
             if ( !bIsAskingUser ) {
                 bIsAskingUser = true;
@@ -48,12 +48,12 @@ $(document).ready(function() {
                 });
 
                 bUserChoseOK = confirm(`Are you sure you want to send the message:\n${theText}\n\nto ${theRecipients.join(', ')}?`);
+                bIsAskingUser = false;
             }
             if ( !bUserChoseOK ) {
                 e.preventDefault();
                 e.stopPropagation();
             }
-            bIsAskingUser = false;
         });
     }
 });

--- a/engage/utils/class_overrides.py
+++ b/engage/utils/class_overrides.py
@@ -72,8 +72,8 @@ class ClassOverrideMixinMustBeFirst:
             #endfor each attr
         #endfor each parent
         if getattr(cls, 'on_apply_overrides', None) and callable(getattr(cls, 'on_apply_overrides')):
-            logger.debug(f"calling {str(cls)}.on_apply_overrides()")
-            cls.on_apply_overrides()
+            logger.debug(f"calling {str(cls)}.on_apply_overrides({under_cls})")
+            cls.on_apply_overrides(under_cls)
         #endif
     #enddef setClassOverrides
 

--- a/engage/utils/class_overrides.py
+++ b/engage/utils/class_overrides.py
@@ -51,6 +51,13 @@ class ClassOverrideMixinMustBeFirst:
         return cls.origattrs.get(attr_name)
     #enddef getOrigAttr
 
+    @staticmethod
+    def setOrigMethod(under_cls, method_name: str) -> None:
+        # child class wonky super() makes this workaround necessary
+        setattr(under_cls, 'orig_'+method_name, under_cls.getOrigClsAttr(method_name))
+        logger.debug(f"override: set attr {str(under_cls)}.orig_{method_name} to {str(under_cls.getOrigClsAttr(method_name))}")
+    #enddef setOrigMethod
+
     @classmethod
     def setClassOverrides(cls) -> None:
         ignore_attrs = getattr(cls, 'override_ignore', ()) + ('on_apply_overrides',)

--- a/engage/utils/class_overrides.py
+++ b/engage/utils/class_overrides.py
@@ -72,6 +72,7 @@ class ClassOverrideMixinMustBeFirst:
             #endfor each attr
         #endfor each parent
         if getattr(cls, 'on_apply_overrides', None) and callable(getattr(cls, 'on_apply_overrides')):
+            logger.debug(f"calling {str(cls)}.on_apply_overrides()")
             cls.on_apply_overrides()
         #endif
     #enddef setClassOverrides

--- a/engage/utils/overrides.py
+++ b/engage/utils/overrides.py
@@ -97,12 +97,13 @@ class EngageOverrides:
         MsgModelOverride.setClassOverrides()
         LabelModelOverride.setClassOverrides()
 
+        from engage.msgs.views.inbox import MsgInboxViewOverrides
+        MsgInboxViewOverrides.setClassOverrides()
+        # override base inbox class before child classes
         from engage.msgs.inbox_msgfailed import ViewInboxFailedMsgsOverrides
         ViewInboxFailedMsgsOverrides.setClassOverrides()
         from engage.msgs.views.exporter import MsgExporterOverrides
         MsgExporterOverrides.setClassOverrides()
-        from engage.msgs.views.inbox import MsgInboxViewOverrides
-        MsgInboxViewOverrides.setClassOverrides()
 
         from temba.mailroom.events import event_renderers
         from engage.mailroom.events import getHistoryContentFromMsg, getHistoryContentFromChannelEvent


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
Failed inbox child class cannot find overridden method in super class; workaround generates an "orig_*" method callable from child class.

#### Release Note
Fixed Failed Msg inbox so it does not generate an error.

#### Breaking Changes
None.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

Messages tab, Failed area selected, you do not see a page that reads simply "Error 500".
