### PR TITLE
P4-4128 & P4-4130 & P4-4129: error NoneType is not iterable

### DIFF
--- a/engage/channels/models.py
+++ b/engage/channels/models.py
@@ -29,7 +29,7 @@ class ChannelOverrides(ClassOverrideMixinMustBeFirst, Channel):
             config = {}
         #endif
         # P4-3462
-        if URN.TEL_SCHEME in schemes:
+        if schemes and URN.TEL_SCHEME in schemes:
             config[Channel.CONFIG_ALLOW_INTERNATIONAL] = True
         #endif
         return cls.getOrigClsAttr('create')(org, user, country, channel_type, name, address, config, role, schemes, **kwargs)


### PR DESCRIPTION
# For the Reviewer
- [ ] Code review complete
- [ ] Testing Complete
- [ ] Quality ORT App Documentation Updated (your name is in the Validator square for this feature)

When this is complete, you should approve the PR via github.

# For the Reviewee

## Summary
When checking for TEL in channel schemes to auto-allow International Calls, ensure it is not None first. 

#### Breaking Changes
Fixed error when adding Nexmo(Vonage) and Twilio channels.

## Quality Assurance

You have gathered the following items:
- [ ] This PR is tagged with a Release Milestone
- [ ] You have a log message clearly identifying when this feature is **working successfully**
- [ ] You have a log message clearly identifying when this feature is **failing**
- [ ] You added a PR against [p4-alerting](https://github.com/istresearch/p4-alerting/) to trigger based on the failure condition above

Given all of the items above, you have updated your Application ORT at the following locations:
- **Features and Alerting**: <link to app ORT>Required.
- **P4 Alerting**: <link to p4-alerting PR>Required.

## Testing and Verification

Test steps should now succeed for:

[Nexmo(Vonage) channel](https://istresearch.atlassian.net/projects/P4?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/P4-T290)

[Twilio Channel](https://istresearch.atlassian.net/projects/P4?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/6320426)

[Telegram Channel](https://istresearch.atlassian.net/projects/P4?selectedItem=com.atlassian.plugins.atlassian-connect-plugin:com.kanoah.test-manager__main-project-page#!/testCase/6319991)