### PR TITLE
PE-317: delete trigger links when delete contact group.

### DIFF
--- a/temba/contacts/models.py
+++ b/temba/contacts/models.py
@@ -1682,6 +1682,10 @@ class ContactGroup(LegacyUUIDMixin, TembaModel, DependencyMixin):
 
         from .tasks import release_group_task
 
+        # delete all triggers for this group
+        for trigger in self.triggers.all():
+            trigger.release(user)
+
         super().release(user)
 
         self.name = self._deleted_name()


### PR DESCRIPTION
copy/paste an RP bugfix, tweak to include all triggers, not just active ones since we see in prod that even deleted triggers are still preventing deleting contact groups.